### PR TITLE
UAF-936 DB Upgrade Script - Assign New 6.0 Permissions to Correct Roles

### DIFF
--- a/src/main/resources/upgrade-files/3.0.1_4.0/rice/kim_upgrade.xml
+++ b/src/main/resources/upgrade-files/3.0.1_4.0/rice/kim_upgrade.xml
@@ -192,27 +192,43 @@
 			<column name="PERM_ID" value="1101" />	
 			<column name="ACTV_IND" value="Y" />
 		</insert>
+		
+		<!-- Changed ROLE_ID from 31 to 2 per UAF-936 -->	
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS1109" />
 			<column name="OBJ_ID" valueNumeric="SYS_GUID() " />
 			<column name="VER_NBR" valueNumeric="1" />
-			<column name="ROLE_ID" value="31" />
+			<column name="ROLE_ID" value="2" />
 			<column name="PERM_ID" value="1102" />	
 			<column name="ACTV_IND" value="Y" />
 		</insert>
+		
+		<!-- Changed ROLE_ID from 49 to 10403 per UAF-936 -->		
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS1004" />
 			<column name="OBJ_ID" valueNumeric="SYS_GUID() " />
 			<column name="VER_NBR" valueNumeric="1" />
-			<column name="ROLE_ID" value="49" />
+			<column name="ROLE_ID" value="10403" />
 			<column name="PERM_ID" value="306" />	
 			<column name="ACTV_IND" value="Y" />
 		</insert>
+		
+		<!-- Added per UAF-936 -->	
+		<insert tableName="KRIM_ROLE_PERM_T">
+			<column name="ROLE_PERM_ID" value="KFS1005" />
+			<column name="OBJ_ID" valueNumeric="SYS_GUID() " />
+			<column name="VER_NBR" valueNumeric="1" />
+			<column name="ROLE_ID" value="56" />
+			<column name="PERM_ID" value="306" />	
+			<column name="ACTV_IND" value="Y" />
+		</insert>
+		
+		<!-- Changed ROLE_ID from 31 to 4 per UAF-936 -->			
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS1110" />
 			<column name="OBJ_ID" valueNumeric="SYS_GUID() " />
 			<column name="VER_NBR" valueNumeric="1" />
-			<column name="ROLE_ID" value="31" />
+			<column name="ROLE_ID" value="4" />
 			<column name="PERM_ID" value="248" />	
 			<column name="ACTV_IND" value="Y" />
 		</insert>

--- a/src/main/resources/upgrade-files/3.0.1_4.0/rice/kim_upgrade_mod.xml
+++ b/src/main/resources/upgrade-files/3.0.1_4.0/rice/kim_upgrade_mod.xml
@@ -213,19 +213,33 @@
 			<column name="PERM_ID" value="12002" />	
 			<column name="ACTV_IND" value="Y" />
 		</insert>
+		
+		<!-- Changed ROLE_ID from 49 to 10403 per UAF-936 -->	
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS1004" />
 			<column name="OBJ_ID" valueNumeric="SYS_GUID() " />
 			<column name="VER_NBR" valueNumeric="1" />
-			<column name="ROLE_ID" value="49" />
+			<column name="ROLE_ID" value="10403" />
 			<column name="PERM_ID" value="306" />	
 			<column name="ACTV_IND" value="Y" />
 		</insert>
+		
+		<!-- Added per UAF-936 -->	
+		<insert tableName="KRIM_ROLE_PERM_T">
+			<column name="ROLE_PERM_ID" value="KFS1005" />
+			<column name="OBJ_ID" valueNumeric="SYS_GUID() " />
+			<column name="VER_NBR" valueNumeric="1" />
+			<column name="ROLE_ID" value="56" />
+			<column name="PERM_ID" value="306" />	
+			<column name="ACTV_IND" value="Y" />
+		</insert>
+		
+		<!-- Changed ROLE_ID from 31 to 4 per UAF-936 -->	
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS1110" />
 			<column name="OBJ_ID" valueNumeric="SYS_GUID() " />
 			<column name="VER_NBR" valueNumeric="1" />
-			<column name="ROLE_ID" value="31" />
+			<column name="ROLE_ID" value="4" />
 			<column name="PERM_ID" value="248" />	
 			<column name="ACTV_IND" value="Y" />
 		</insert>
@@ -288,6 +302,9 @@
 			<column name="KIM_ATTR_DEFN_ID" value="1" />
 			<column name="ATTR_VAL" value="laborEnterpriseFeederFileSetType" />
 		</insert>
+		
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->	
+		<!--		
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFSLD1" />
 			<column name="OBJ_ID" valueNumeric="SYS_GUID() " />
@@ -295,7 +312,8 @@
 			<column name="ROLE_ID" value="45" />
 			<column name="PERM_ID" value="12005" />	
 			<column name="ACTV_IND" value="Y" />
-		</insert>
+		</insert> 
+		-->
 		<modifySql dbms="mysql">
 			<replace replace="SYS_GUID" with="UUID" />
 		</modifySql>

--- a/src/main/resources/upgrade-files/4.0_4.1/rice/kim_security_module.xml
+++ b/src/main/resources/upgrade-files/4.0_4.1/rice/kim_security_module.xml
@@ -307,6 +307,8 @@
 			<column name="ATTR_VAL" value="AccessSecuritySimpleMaintenanceDocument" />
 		</insert>
 	
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="PERM_ID" value="KFSSEC6001" />
 			<column name="ROLE_ID" value="51" />
@@ -315,7 +317,7 @@
 			<column name="VER_NBR" valueNumeric="1" />
 			<column name="ACTV_IND" value="Y" />
 		</insert>
-	
+		-->
 	
 		<modifySql dbms="mysql">
 			<replace replace="SYS_GUID" with="UUID" />
@@ -345,6 +347,8 @@
 			<column name="ATTR_VAL" value="KFS-SEC" />
 		</insert>
 	
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="PERM_ID" value="KFSSEC6002" />
 			<column name="ROLE_ID" value="51" />
@@ -353,7 +357,7 @@
 			<column name="VER_NBR" valueNumeric="1" />
 			<column name="ACTV_IND" value="Y" />
 		</insert>
-	
+		-->
 	
 		<modifySql dbms="mysql">
 			<replace replace="SYS_GUID" with="UUID" />
@@ -383,6 +387,8 @@
 			<column name="ATTR_VAL" value="KFS-SEC" />
 		</insert>
 	
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="PERM_ID" value="KFSSEC6003" />
 			<column name="ROLE_ID" value="51" />
@@ -391,7 +397,7 @@
 			<column name="VER_NBR" valueNumeric="1" />
 			<column name="ACTV_IND" value="Y" />
 		</insert>
-	
+		-->
 	
 		<modifySql dbms="mysql">
 			<replace replace="SYS_GUID" with="UUID" />
@@ -431,6 +437,8 @@
 			<column name="ATTR_VAL" value="PreRoute" />
 		</insert>
 	
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="PERM_ID" value="KFSSEC6004" />
 			<column name="ROLE_ID" value="51" />
@@ -439,7 +447,7 @@
 			<column name="VER_NBR" valueNumeric="1" />
 			<column name="ACTV_IND" value="Y" />
 		</insert>
-	
+		-->
 	
 		<modifySql dbms="mysql">
 			<replace replace="SYS_GUID" with="UUID" />

--- a/src/main/resources/upgrade-files/4.1.1_5.0/rice_server/kim_upgrade.xml
+++ b/src/main/resources/upgrade-files/4.1.1_5.0/rice_server/kim_upgrade.xml
@@ -210,6 +210,9 @@
 			<column name='KIM_ATTR_DEFN_ID' value='1' />
 			<column name='ATTR_VAL' value='laborEnterpriseFeederFileSetType' />
 		</insert>
+		
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--		
 		<insert tableName='KRIM_ROLE_PERM_T'>
 			<column name='ROLE_PERM_ID' value='45_KFSLD6987' />
 			<column name='OBJ_ID' value='KFSLD6987j' />
@@ -218,6 +221,8 @@
 			<column name='PERM_ID' value='KFSLD6987' />
 			<column name='ACTV_IND' value='Y' />
 		</insert>
+		-->
+		
 	</changeSet>
 	<changeSet author="KFS50" id="KFSMI-7145">
 		<insert tableName='KRIM_PERM_T'>
@@ -333,6 +338,9 @@
 			<column name="KIM_ATTR_DEFN_ID" valueNumeric=" (select kim_attr_defn_id from KRIM_ATTR_DEFN_T where nm = 'editMode') "/>
 			<column name="ATTR_VAL" value="immediateDisbursementEntryMode"/>
 		</insert>
+		
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--		
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFSSYS6007-1"/>
 			<column name="OBJ_ID" valueNumeric="sys_guid() "/>
@@ -349,6 +357,7 @@
 			<column name="PERM_ID" value="KFSSYS6007"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		-->
 	    <modifySql dbms="mysql">
 	      <replace replace="sys_guid()" with="uuid()" />
 	    </modifySql>
@@ -701,6 +710,8 @@
 			<column name="PERM_ID" value="KFSMI6886-PRM3" />
 			<column name="ACTV_IND" value="Y" />
 		</insert>
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--		
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFSMI6886-RLPRM4" />
 			<column name="OBJ_ID" valueNumeric="sys_guid() "/>
@@ -709,6 +720,7 @@
 			<column name="PERM_ID" value="KFSMI6886-PRM3" />
 			<column name="ACTV_IND" value="Y" />
 		</insert>
+		-->
 	    <modifySql dbms='mysql'>
 	      <replace replace="sys_guid()" with="uuid()" />
 	    </modifySql>
@@ -802,6 +814,9 @@
 			<column name="KIM_ATTR_DEFN_ID" value="1" />
 			<column name="ATTR_VAL" value="semaphoreInputFileTypeError" />
 		</insert>
+		
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFSCNTRB199-RP1" />
 			<column name="OBJ_ID" value="KFSCNTRB199-RP1"/>
@@ -809,7 +824,8 @@
 			<column name="ROLE_ID" value="51" />
 			<column name="PERM_ID" value="KFSCNTRB199-P1" />
 			<column name="ACTV_IND" value="Y" />
-		</insert>
+		</insert> 
+		-->
 
 		<insert tableName="KRIM_PERM_T">
 			<column name="PERM_ID" value="KFSCNTRB199-P2" />
@@ -839,6 +855,9 @@
 			<column name="KIM_ATTR_DEFN_ID" value="KFSCNTRB199-ATTRDEF1" />
 			<column name="ATTR_VAL" value="staging/sys/batchContainer/*" />
 		</insert>
+		
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFSCNTRB199-RP2" />
 			<column name="OBJ_ID" value="KFSCNTRB199-RP2"/>
@@ -846,7 +865,8 @@
 			<column name="ROLE_ID" value="51" />
 			<column name="PERM_ID" value="KFSCNTRB199-P2" />
 			<column name="ACTV_IND" value="Y" />
-		</insert>
+		</insert> 
+		-->
 	</changeSet>
 	
 	<changeSet author="KFS50" id="WORKSTUDY_WORKFLOW_UPDATES">

--- a/src/main/resources/upgrade-files/4.1.1_5.0/rice_server/kim_upgrade_mod.xml
+++ b/src/main/resources/upgrade-files/4.1.1_5.0/rice_server/kim_upgrade_mod.xml
@@ -143,6 +143,9 @@
 			<column name='KIM_ATTR_DEFN_ID' value='1' />
 			<column name='ATTR_VAL' value='laborEnterpriseFeederFileSetType' />
 		</insert>
+		
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName='KRIM_ROLE_PERM_T'>
 			<column name='ROLE_PERM_ID' value='45_KFSLD6987' />
 			<column name='OBJ_ID' value='KFSLD6987j' />
@@ -151,6 +154,7 @@
 			<column name='PERM_ID' value='KFSLD6987' />
 			<column name='ACTV_IND' value='Y' />
 		</insert>
+		-->
 	</changeSet>
 	<changeSet author="KFS50" id="KFSMI-7145">
 		<insert tableName='KRIM_PERM_T'>
@@ -734,6 +738,9 @@
 			<column name="KIM_ATTR_DEFN_ID" value="1" />
 			<column name="ATTR_VAL" value="semaphoreInputFileTypeError" />
 		</insert>
+		
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFSCNTRB199-RP1" />
 			<column name="OBJ_ID" value="KFSCNTRB199-RP1"/>
@@ -742,7 +749,8 @@
 			<column name="PERM_ID" value="KFSCNTRB199-P1" />
 			<column name="ACTV_IND" value="Y" />
 		</insert>
-
+		-->
+		
 		<insert tableName="KRIM_PERM_T">
 			<column name="PERM_ID" value="KFSCNTRB199-P2" />
 			<column name="OBJ_ID" value="KFSCNTRB199-P2"/>
@@ -771,6 +779,9 @@
 			<column name="KIM_ATTR_DEFN_ID" value="KFSCNTRB199-ATTRDEF1" />
 			<column name="ATTR_VAL" value="staging/sys/batchContainer/*" />
 		</insert>
+		
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFSCNTRB199-RP2" />
 			<column name="OBJ_ID" value="KFSCNTRB199-RP2"/>
@@ -779,6 +790,7 @@
 			<column name="PERM_ID" value="KFSCNTRB199-P2" />
 			<column name="ACTV_IND" value="Y" />
 		</insert>
+		-->
 	</changeSet>
 	
 	<changeSet author="KFS50" id="WORKSTUDY_WORKFLOW_UPDATES">

--- a/src/main/resources/upgrade-files/5.0.2_5.0.3/rice_server/kim_upgrade.xml
+++ b/src/main/resources/upgrade-files/5.0.2_5.0.3/rice_server/kim_upgrade.xml
@@ -15,6 +15,8 @@
 			<column name="ACTV_IND" value="Y" />
 		</insert>
 		
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFSCNTRB1343-RLPRM1-1" />
 			<column name="OBJ_ID" valueNumeric="sys_guid() "/>
@@ -23,7 +25,10 @@
 			<column name="PERM_ID" value="KFSCNTRB1343-PRM1" />
 			<column name="ACTV_IND" value="Y" />
 		</insert>
+		-->
 		
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFSCNTRB1343-RLPRM1-2" />
 			<column name="OBJ_ID" valueNumeric="sys_guid() "/>
@@ -32,6 +37,8 @@
 			<column name="PERM_ID" value="KFSCNTRB1343-PRM1"/>
 			<column name="ACTV_IND" value="Y" />
 		</insert>
+		-->
+		
 		<insert tableName="KRIM_PERM_ATTR_DATA_T">
 			<column name="ATTR_DATA_ID" value="KFSCNTRB1343-PRMATTR1" />
 			<column name="OBJ_ID" valueNumeric="sys_guid() " />

--- a/src/main/resources/upgrade-files/5.0.5_5.1/rice_server/kim_upgrade.xml
+++ b/src/main/resources/upgrade-files/5.0.5_5.1/rice_server/kim_upgrade.xml
@@ -26,11 +26,12 @@
 			<column name="ATTR_VAL" value="researchParticipantInboundServiceInputType" />
 		</insert>
 
+		<!-- Changed ROLE_ID from 20 to 10428 per UAF-936 -->
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFSCNTRB705-RLPRM1" />
 			<column name="OBJ_ID" valueComputed="SYS_GUID()" />
 			<column name="VER_NBR" valueNumeric="1" />
-			<column name="ROLE_ID" value="20" />
+			<column name="ROLE_ID" value="10428" />
 			<column name="PERM_ID" value="KFSCNTRB705-PRM1" />
 			<column name="ACTV_IND" value="Y" />
 		</insert>
@@ -66,6 +67,8 @@
 			<column name="ATTR_VAL" value="paymentGroup.payeeName" />
 		</insert>
 
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFSCNTRB705-RLPRM2" />
 			<column name="OBJ_ID" valueComputed="SYS_GUID()" />
@@ -74,7 +77,8 @@
 			<column name="PERM_ID" value="KFSCNTRB705-PRM2" />
 			<column name="ACTV_IND" value="Y" />
 		</insert>
-
+		-->
+		
 		<insert tableName="KRIM_PERM_T">
 			<column name="PERM_ID" value="KFSCNTRB705-PRM3" />
 			<column name="OBJ_ID" valueComputed="SYS_GUID()" />
@@ -106,6 +110,8 @@
 			<column name="ATTR_VAL" value="paymentGroup.street" />
 		</insert>
 
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFSCNTRB705-RLPRM3" />
 			<column name="OBJ_ID" valueComputed="SYS_GUID()" />
@@ -114,7 +120,8 @@
 			<column name="PERM_ID" value="KFSCNTRB705-PRM3" />
 			<column name="ACTV_IND" value="Y" />
 		</insert>
-
+		-->
+		
 		<insert tableName="KRIM_PERM_T">
 			<column name="PERM_ID" value="KFSCNTRB705-PRM4" />
 			<column name="OBJ_ID" valueComputed="SYS_GUID()" />
@@ -146,6 +153,8 @@
 			<column name="ATTR_VAL" value="paymentGroup.city" />
 		</insert>
 
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFSCNTRB705-RLPRM4" />
 			<column name="OBJ_ID" valueComputed="SYS_GUID()" />
@@ -154,7 +163,8 @@
 			<column name="PERM_ID" value="KFSCNTRB705-PRM4" />
 			<column name="ACTV_IND" value="Y" />
 		</insert>
-
+		-->
+		
 		<insert tableName="KRIM_PERM_T">
 			<column name="PERM_ID" value="KFSCNTRB705-PRM5" />
 			<column name="OBJ_ID" valueComputed="SYS_GUID()" />
@@ -186,6 +196,8 @@
 			<column name="ATTR_VAL" value="paymentGroup.state" />
 		</insert>
 
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFSCNTRB705-RLPRM5" />
 			<column name="OBJ_ID" valueComputed="SYS_GUID()" />
@@ -194,7 +206,8 @@
 			<column name="PERM_ID" value="KFSCNTRB705-PRM5" />
 			<column name="ACTV_IND" value="Y" />
 		</insert>
-
+		-->
+		
 		<insert tableName="KRIM_PERM_T">
 			<column name="PERM_ID" value="KFSCNTRB705-PRM6" />
 			<column name="OBJ_ID" valueComputed="SYS_GUID()" />
@@ -226,6 +239,8 @@
 			<column name="ATTR_VAL" value="paymentGroup.zipCd" />
 		</insert>
 
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFSCNTRB705-RLPRM6" />
 			<column name="OBJ_ID" valueComputed="SYS_GUID()" />
@@ -234,7 +249,8 @@
 			<column name="PERM_ID" value="KFSCNTRB705-PRM6" />
 			<column name="ACTV_IND" value="Y" />
 		</insert>
-
+		-->
+		
 		<insert tableName="KRIM_PERM_T">
 			<column name="PERM_ID" value="KFSCNTRB705-PRM7" />
 			<column name="OBJ_ID" valueComputed="SYS_GUID()" />
@@ -266,6 +282,8 @@
 			<column name="ATTR_VAL" value="staging/PDP/paymentExtract/RP-Upload*" />
 		</insert>
 		
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFSCNTRB705-RLPRM7" />
 			<column name="OBJ_ID" valueComputed="SYS_GUID()" />
@@ -274,6 +292,7 @@
 			<column name="PERM_ID" value="KFSCNTRB705-PRM7" />
 			<column name="ACTV_IND" value="Y" />
 		</insert>
+		-->
 		
 		<modifySql dbms="mysql">
 	        <replace replace="SYS_GUID()" with="UUID() " />

--- a/src/main/resources/upgrade-files/5.0.5_5.1/rice_server/kim_upgrade_mod.xml
+++ b/src/main/resources/upgrade-files/5.0.5_5.1/rice_server/kim_upgrade_mod.xml
@@ -26,11 +26,12 @@
 			<column name="ATTR_VAL" value="researchParticipantInboundServiceInputType" />
 		</insert>
 
+		<!-- Changed ROLE_ID from 20 to 10428 per UAF-936 -->
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFSCNTRB705-RLPRM1" />
 			<column name="OBJ_ID" value="d2af2070-d668-4123-8d8e-a333f5df20b1" />
 			<column name="VER_NBR" valueNumeric="1" />
-			<column name="ROLE_ID" value="20" />
+			<column name="ROLE_ID" value="10428" />
 			<column name="PERM_ID" value="KFSCNTRB705-PRM1" />
 			<column name="ACTV_IND" value="Y" />
 		</insert>
@@ -66,6 +67,8 @@
 			<column name="ATTR_VAL" value="paymentGroup.payeeName" />
 		</insert>
 
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFSCNTRB705-RLPRM2" />
 			<column name="OBJ_ID" value="046c3926-ed43-4e8a-bb30-67a786091067" />
@@ -74,7 +77,8 @@
 			<column name="PERM_ID" value="KFSCNTRB705-PRM2" />
 			<column name="ACTV_IND" value="Y" />
 		</insert>
-
+		-->
+		
 		<insert tableName="KRIM_PERM_T">
 			<column name="PERM_ID" value="KFSCNTRB705-PRM3" />
 			<column name="OBJ_ID" value="1deaaf16-c1c9-4a46-be80-c2bbe1009656" />
@@ -106,6 +110,8 @@
 			<column name="ATTR_VAL" value="paymentGroup.street" />
 		</insert>
 
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFSCNTRB705-RLPRM3" />
 			<column name="OBJ_ID" value="50c628b1-c67f-4e97-b39d-db292b96f210" />
@@ -114,7 +120,8 @@
 			<column name="PERM_ID" value="KFSCNTRB705-PRM3" />
 			<column name="ACTV_IND" value="Y" />
 		</insert>
-
+		-->
+		
 		<insert tableName="KRIM_PERM_T">
 			<column name="PERM_ID" value="KFSCNTRB705-PRM4" />
 			<column name="OBJ_ID" value="b4c3714a-2232-413c-8f24-82c556897f14" />
@@ -146,6 +153,8 @@
 			<column name="ATTR_VAL" value="paymentGroup.city" />
 		</insert>
 
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFSCNTRB705-RLPRM4" />
 			<column name="OBJ_ID" value="e0040260-0f79-410f-9944-995384c6e593" />
@@ -154,7 +163,8 @@
 			<column name="PERM_ID" value="KFSCNTRB705-PRM4" />
 			<column name="ACTV_IND" value="Y" />
 		</insert>
-
+		-->
+		
 		<insert tableName="KRIM_PERM_T">
 			<column name="PERM_ID" value="KFSCNTRB705-PRM5" />
 			<column name="OBJ_ID" value="2cc3fd9a-d889-446f-bbe7-8668cb611dee" />
@@ -186,6 +196,8 @@
 			<column name="ATTR_VAL" value="paymentGroup.state" />
 		</insert>
 
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFSCNTRB705-RLPRM5" />
 			<column name="OBJ_ID" value="00124dff-78c2-4864-8ae0-caadc9a539ab" />
@@ -194,7 +206,8 @@
 			<column name="PERM_ID" value="KFSCNTRB705-PRM5" />
 			<column name="ACTV_IND" value="Y" />
 		</insert>
-
+		-->
+		
 		<insert tableName="KRIM_PERM_T">
 			<column name="PERM_ID" value="KFSCNTRB705-PRM6" />
 			<column name="OBJ_ID" value="4d8420e8-3fad-4073-8f44-4a8b8165f4f9" />
@@ -226,6 +239,8 @@
 			<column name="ATTR_VAL" value="paymentGroup.zipCd" />
 		</insert>
 
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFSCNTRB705-RLPRM6" />
 			<column name="OBJ_ID" value="9fd5cb99-6a21-48d9-be9d-93dfd7bae108" />
@@ -234,7 +249,8 @@
 			<column name="PERM_ID" value="KFSCNTRB705-PRM6" />
 			<column name="ACTV_IND" value="Y" />
 		</insert>
-
+		-->
+		
 		<insert tableName="KRIM_PERM_T">
 			<column name="PERM_ID" value="KFSCNTRB705-PRM7" />
 			<column name="OBJ_ID" value="faa60363-d8cb-4ea9-9b69-eb7feba8ece9" />
@@ -266,6 +282,8 @@
 			<column name="ATTR_VAL" value="staging/PDP/paymentExtract/RP-Upload*" />
 		</insert>
 		
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFSCNTRB705-RLPRM7" />
 			<column name="OBJ_ID" value="e32ea686-2d4f-4689-bf16-0cc48bb18a68" />
@@ -274,6 +292,7 @@
 			<column name="PERM_ID" value="KFSCNTRB705-PRM7" />
 			<column name="ACTV_IND" value="Y" />
 		</insert>
+		-->
 	</changeSet>
 	<changeSet author="KFS52" id="KFSCNTRB-762">
 		<comment>KFSCNTRB-762 Create Trial Balance in KFS</comment>

--- a/src/main/resources/upgrade-files/5.0_5.0.1/rice_server/kim_upgrade.xml
+++ b/src/main/resources/upgrade-files/5.0_5.0.1/rice_server/kim_upgrade.xml
@@ -50,6 +50,9 @@
 			<column name="DESC_TXT" value="Allow access to modules, even when locked." />
 			<column name="ACTV_IND" value="Y" />
 		</insert>
+		
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFSCNTRB65-RLPRM1" />
 			<column name="OBJ_ID" valueNumeric="sys_guid() "/>
@@ -58,6 +61,8 @@
 			<column name="PERM_ID" value="KFSCNTRB65-PRM1" />
 			<column name="ACTV_IND" value="Y" />
 		</insert>
+		-->
+		
 		<modifySql dbms='mysql'>
 	      <replace replace="sys_guid()" with="uuid()" />
 	    </modifySql>
@@ -110,6 +115,8 @@
 			<column name="ATTR_VAL" value="KFS" />
 		</insert>
 
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFSMI9598-RLPRM1" />
 			<column name="OBJ_ID" value="KFSMI9598-RLPRM1" />
@@ -118,6 +125,7 @@
 			<column name="PERM_ID" value="KFSMI9598-PRM1" />
 			<column name="ACTV_IND" value="Y" />
 		</insert>
+		-->
 		
 		<insert tableName="KRIM_PERM_T">
 			<column name="PERM_ID" value="KFSMI9598-PRM2" />
@@ -139,7 +147,9 @@
 			<column name="KIM_ATTR_DEFN_ID" value="13" />
 			<column name="ATTR_VAL" value="KFS" />
 		</insert>
-
+		
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFSMI9598-RLPRM2" />
 			<column name="OBJ_ID" value="KFSMI9598-RLPRM2" />
@@ -148,7 +158,8 @@
 			<column name="PERM_ID" value="KFSMI9598-PRM2" />
 			<column name="ACTV_IND" value="Y" />
 		</insert>
-
+		-->
+		
 		<insert tableName="KRIM_PERM_T">
 			<column name="PERM_ID" value="KFSMI9598-PRM3" />
 			<column name="OBJ_ID" value="KFSMI9598-PRM3" />
@@ -170,6 +181,8 @@
 			<column name="ATTR_VAL" value="KFS" />
 		</insert>
 
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFSMI9598-RLPRM3" />
 			<column name="OBJ_ID" value="KFSMI9598-RLPRM3" />
@@ -178,7 +191,8 @@
 			<column name="PERM_ID" value="KFSMI9598-PRM3" />
 			<column name="ACTV_IND" value="Y" />
 		</insert>
-
+		-->
+		
 	</changeSet>
 
 	<changeSet author="KFS501" id="FIX_NAMESPACE_ON_TYPE_SERVICES">
@@ -284,6 +298,8 @@
 			<column name="ACTV_IND" value="Y" />
 		</insert>
 		<!-- This permission overrides a top-level permission granted to KFS-SYS / Operations - so we need to restore that. -->
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="PREQ_SU_DISAPPROVE_OPS" />
 			<column name="OBJ_ID" valueComputed="sys_guid() "/>
@@ -292,6 +308,7 @@
 			<column name="PERM_ID" value="PREQ_SU_DISAPPROVE" />
 			<column name="ACTV_IND" value="Y" />
 		</insert>
+		-->
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="PREQ_SU_DISAPPROVE_SYSUSER" />
 			<column name="OBJ_ID" valueComputed="sys_guid() "/>

--- a/src/main/resources/upgrade-files/5.0_5.0.1/rice_server/kim_upgrade_mod.xml
+++ b/src/main/resources/upgrade-files/5.0_5.0.1/rice_server/kim_upgrade_mod.xml
@@ -80,6 +80,8 @@
 			<column name="ATTR_VAL" value="KFS" />
 		</insert>
 
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFSMI9598-RLPRM1" />
 			<column name="OBJ_ID" value="KFSMI9598-RLPRM1" />
@@ -88,6 +90,7 @@
 			<column name="PERM_ID" value="KFSMI9598-PRM1" />
 			<column name="ACTV_IND" value="Y" />
 		</insert>
+		-->
 		
 		<insert tableName="KRIM_PERM_T">
 			<column name="PERM_ID" value="KFSMI9598-PRM2" />
@@ -110,6 +113,8 @@
 			<column name="ATTR_VAL" value="KFS" />
 		</insert>
 
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFSMI9598-RLPRM2" />
 			<column name="OBJ_ID" value="KFSMI9598-RLPRM2" />
@@ -118,7 +123,8 @@
 			<column name="PERM_ID" value="KFSMI9598-PRM2" />
 			<column name="ACTV_IND" value="Y" />
 		</insert>
-
+		-->
+		
 		<insert tableName="KRIM_PERM_T">
 			<column name="PERM_ID" value="KFSMI9598-PRM3" />
 			<column name="OBJ_ID" value="KFSMI9598-PRM3" />
@@ -140,6 +146,8 @@
 			<column name="ATTR_VAL" value="KFS" />
 		</insert>
 
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFSMI9598-RLPRM3" />
 			<column name="OBJ_ID" value="KFSMI9598-RLPRM3" />
@@ -148,7 +156,8 @@
 			<column name="PERM_ID" value="KFSMI9598-PRM3" />
 			<column name="ACTV_IND" value="Y" />
 		</insert>
-
+		-->
+		
 	</changeSet>
 
 	<changeSet author="KFS501" id="FIX_NAMESPACE_ON_TYPE_SERVICES">

--- a/src/main/resources/upgrade-files/5.1.2_5.2/rice_server/kim_upgrade.xml
+++ b/src/main/resources/upgrade-files/5.1.2_5.2/rice_server/kim_upgrade.xml
@@ -2915,6 +2915,9 @@
 			<column name="PERM_ID" value="KFS10282"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10001"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-002"/>
@@ -2922,6 +2925,8 @@
 			<column name="PERM_ID" value="KFS10282"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		-->
+		
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10002"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-003"/>
@@ -2929,6 +2934,9 @@
 			<column name="PERM_ID" value="KFS10282"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10003"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-004"/>
@@ -2943,6 +2951,7 @@
 			<column name="PERM_ID" value="KFS10284"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		-->
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10006"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-007"/>
@@ -2950,6 +2959,9 @@
 			<column name="PERM_ID" value="KFS10285"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10007"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-008"/>
@@ -2957,6 +2969,8 @@
 			<column name="PERM_ID" value="KFS10285"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		-->
+		
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10008"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-009"/>
@@ -2978,6 +2992,9 @@
 			<column name="PERM_ID" value="KFS10286"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10011"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-012"/>
@@ -2985,6 +3002,8 @@
 			<column name="PERM_ID" value="KFS10286"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		-->
+		
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10012"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-013"/>
@@ -3356,6 +3375,9 @@
 			<column name="PERM_ID" value="KFS10307"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10080"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-081"/>
@@ -3363,6 +3385,8 @@
 			<column name="PERM_ID" value="KFS10307"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		-->
+		
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10081"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-082"/>
@@ -3398,6 +3422,9 @@
 			<column name="PERM_ID" value="KFS10308"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10086"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-087"/>
@@ -3405,6 +3432,8 @@
 			<column name="PERM_ID" value="KFS10308"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		-->
+		
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10087"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-088"/>
@@ -3531,6 +3560,9 @@
 			<column name="PERM_ID" value="KFS10314"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10114"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-116"/>
@@ -3545,6 +3577,8 @@
 			<column name="PERM_ID" value="KFS10315"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		-->
+		
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10118"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-120"/>
@@ -3566,6 +3600,9 @@
 			<column name="PERM_ID" value="KFS10318"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10121"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-123"/>
@@ -3615,6 +3652,8 @@
 			<column name="PERM_ID" value="KFS10294"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		-->
+		
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10129"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-131"/>
@@ -3629,6 +3668,9 @@
 			<column name="PERM_ID" value="KFS10322"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10131"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-133"/>
@@ -3636,6 +3678,8 @@
 			<column name="PERM_ID" value="KFS10323"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		-->
+		
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10133"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-135"/>
@@ -3671,6 +3715,9 @@
 			<column name="PERM_ID" value="KFS10328"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10141"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-141"/>
@@ -3678,6 +3725,8 @@
 			<column name="PERM_ID" value="KFS10328"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		-->
+		
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10142"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-142"/>
@@ -3762,6 +3811,9 @@
 			<column name="PERM_ID" value="KFS10294"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10166"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-166"/>
@@ -3790,6 +3842,8 @@
 			<column name="PERM_ID" value="KFS10336"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		-->
+		
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10170"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-170"/>
@@ -3804,6 +3858,9 @@
 			<column name="PERM_ID" value="KFS10330"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10172"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-172"/>
@@ -3811,6 +3868,8 @@
 			<column name="PERM_ID" value="KFS10330"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		-->
+		
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10173"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-173"/>
@@ -3951,6 +4010,9 @@
 			<column name="PERM_ID" value="KFS10341"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10195"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-195"/>
@@ -3958,6 +4020,8 @@
 			<column name="PERM_ID" value="KFS10342"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		-->
+		
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10196"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-196"/>
@@ -3965,6 +4029,9 @@
 			<column name="PERM_ID" value="KFS10341"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10376"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-197"/>
@@ -3972,6 +4039,8 @@
 			<column name="PERM_ID" value="KFS10372"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		-->
+		
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10377"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-198"/>
@@ -3979,6 +4048,9 @@
 			<column name="PERM_ID" value="KFS10372"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10378"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-199"/>
@@ -3986,6 +4058,8 @@
 			<column name="PERM_ID" value="KFS10373"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		-->
+		
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10379"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-200"/>
@@ -4000,6 +4074,9 @@
 			<column name="PERM_ID" value="KFS10387"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10424"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-206"/>
@@ -4063,6 +4140,8 @@
 			<column name="PERM_ID" value="KFS10405"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		-->
+		
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10438"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-215"/>
@@ -4140,6 +4219,9 @@
 			<column name="PERM_ID" value="KFS10451"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10473"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-234"/>
@@ -4154,6 +4236,8 @@
 			<column name="PERM_ID" value="KFS10470"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		-->
+		
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10507"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-252"/>
@@ -4161,6 +4245,9 @@
 			<column name="PERM_ID" value="KFS10503"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10512"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-253"/>
@@ -4175,6 +4262,8 @@
 			<column name="PERM_ID" value="KFS10513"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		-->
+		
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10521"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-256"/>
@@ -4399,6 +4488,9 @@
 			<column name="PERM_ID" value="KFS10722"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10729"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-308"/>
@@ -4406,6 +4498,8 @@
 			<column name="PERM_ID" value="KFS10723"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		-->
+		
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10732"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-309"/>
@@ -4448,6 +4542,9 @@
 			<column name="PERM_ID" value="KFS10312"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10741"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-315"/>
@@ -4476,6 +4573,8 @@
 			<column name="PERM_ID" value="KFS10298"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		-->
+		
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10745"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-319"/>
@@ -4483,6 +4582,9 @@
 			<column name="PERM_ID" value="KFS10735"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10749"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-320"/>
@@ -4490,6 +4592,8 @@
 			<column name="PERM_ID" value="KFS10746"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		-->
+		
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10750"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-321"/>
@@ -4518,6 +4622,9 @@
 			<column name="PERM_ID" value="KFS10328"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10757"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-325"/>
@@ -4532,6 +4639,8 @@
 			<column name="PERM_ID" value="KFS10758"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		-->
+		
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10766"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-327"/>
@@ -4546,6 +4655,9 @@
 			<column name="PERM_ID" value="KFS10767"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10771"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-329"/>
@@ -4560,6 +4672,8 @@
 			<column name="PERM_ID" value="KFS10767"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		-->
+		
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10776"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-331"/>
@@ -4574,6 +4688,9 @@
 			<column name="PERM_ID" value="KFS10773"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10778"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-333"/>
@@ -4581,6 +4698,8 @@
 			<column name="PERM_ID" value="KFS10773"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		-->
+		
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10782"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-334"/>
@@ -4595,6 +4714,9 @@
 			<column name="PERM_ID" value="KFS10779"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10784"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-336"/>
@@ -4602,6 +4724,8 @@
 			<column name="PERM_ID" value="KFS10779"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		-->
+		
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10789"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-337"/>
@@ -4630,6 +4754,9 @@
 			<column name="PERM_ID" value="KFS10746"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10801"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-341"/>
@@ -4637,6 +4764,8 @@
 			<column name="PERM_ID" value="KFS10798"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		-->
+		
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10802"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-342"/>
@@ -4672,6 +4801,9 @@
 			<column name="PERM_ID" value="KFS10804"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10809"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-347"/>
@@ -4679,6 +4811,8 @@
 			<column name="PERM_ID" value="KFS10804"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		-->
+		
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10810"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-348"/>
@@ -4707,6 +4841,9 @@
 			<column name="PERM_ID" value="KFS10811"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10815"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-352"/>
@@ -4714,6 +4851,8 @@
 			<column name="PERM_ID" value="KFS10811"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		-->
+		
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10816"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-353"/>
@@ -4742,6 +4881,9 @@
 			<column name="PERM_ID" value="KFS10821"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10826"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-358"/>
@@ -4749,6 +4891,8 @@
 			<column name="PERM_ID" value="KFS10821"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		-->
+		
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10827"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-359"/>

--- a/src/main/resources/upgrade-files/5.1.2_5.2/rice_server/kim_upgrade_mod.xml
+++ b/src/main/resources/upgrade-files/5.1.2_5.2/rice_server/kim_upgrade_mod.xml
@@ -2896,6 +2896,9 @@
 			<column name="PERM_ID" value="KFS10282"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10001"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-002"/>
@@ -2903,6 +2906,8 @@
 			<column name="PERM_ID" value="KFS10282"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		-->
+		
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10002"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-003"/>
@@ -2910,6 +2915,9 @@
 			<column name="PERM_ID" value="KFS10282"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10003"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-004"/>
@@ -2924,6 +2932,8 @@
 			<column name="PERM_ID" value="KFS10284"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		-->
+		
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10006"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-007"/>
@@ -2931,6 +2941,9 @@
 			<column name="PERM_ID" value="KFS10285"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10007"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-008"/>
@@ -2938,6 +2951,8 @@
 			<column name="PERM_ID" value="KFS10285"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		-->
+		
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10008"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-009"/>
@@ -2959,6 +2974,9 @@
 			<column name="PERM_ID" value="KFS10286"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10011"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-012"/>
@@ -2966,6 +2984,8 @@
 			<column name="PERM_ID" value="KFS10286"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		-->
+		
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10012"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-013"/>
@@ -3337,6 +3357,9 @@
 			<column name="PERM_ID" value="KFS10307"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10080"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-081"/>
@@ -3344,6 +3367,8 @@
 			<column name="PERM_ID" value="KFS10307"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		-->
+		
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10081"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-082"/>
@@ -3379,6 +3404,9 @@
 			<column name="PERM_ID" value="KFS10308"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10086"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-087"/>
@@ -3386,6 +3414,8 @@
 			<column name="PERM_ID" value="KFS10308"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		-->
+		
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10087"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-088"/>
@@ -3512,6 +3542,9 @@
 			<column name="PERM_ID" value="KFS10314"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10114"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-116"/>
@@ -3526,6 +3559,8 @@
 			<column name="PERM_ID" value="KFS10315"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		-->
+		
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10118"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-120"/>
@@ -3547,6 +3582,9 @@
 			<column name="PERM_ID" value="KFS10318"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10121"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-123"/>
@@ -3596,6 +3634,8 @@
 			<column name="PERM_ID" value="KFS10294"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		-->
+		
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10129"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-131"/>
@@ -3610,6 +3650,9 @@
 			<column name="PERM_ID" value="KFS10322"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10131"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-133"/>
@@ -3617,6 +3660,8 @@
 			<column name="PERM_ID" value="KFS10323"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		-->
+		
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10133"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-135"/>
@@ -3652,6 +3697,9 @@
 			<column name="PERM_ID" value="KFS10328"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10141"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-141"/>
@@ -3659,6 +3707,8 @@
 			<column name="PERM_ID" value="KFS10328"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		-->
+		
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10142"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-142"/>
@@ -3743,6 +3793,9 @@
 			<column name="PERM_ID" value="KFS10294"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10166"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-166"/>
@@ -3771,6 +3824,8 @@
 			<column name="PERM_ID" value="KFS10336"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		-->
+		
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10170"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-170"/>
@@ -3785,6 +3840,9 @@
 			<column name="PERM_ID" value="KFS10330"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10172"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-172"/>
@@ -3792,6 +3850,8 @@
 			<column name="PERM_ID" value="KFS10330"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		-->
+		
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10173"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-173"/>
@@ -3932,6 +3992,9 @@
 			<column name="PERM_ID" value="KFS10341"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10195"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-195"/>
@@ -3939,6 +4002,8 @@
 			<column name="PERM_ID" value="KFS10342"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		-->
+		
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10196"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-196"/>
@@ -3946,6 +4011,9 @@
 			<column name="PERM_ID" value="KFS10341"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10376"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-197"/>
@@ -3953,6 +4021,8 @@
 			<column name="PERM_ID" value="KFS10372"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		-->
+		
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10377"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-198"/>
@@ -3960,6 +4030,9 @@
 			<column name="PERM_ID" value="KFS10372"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10378"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-199"/>
@@ -3967,6 +4040,8 @@
 			<column name="PERM_ID" value="KFS10373"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		-->
+		
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10379"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-200"/>
@@ -3981,6 +4056,9 @@
 			<column name="PERM_ID" value="KFS10387"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10424"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-206"/>
@@ -4044,6 +4122,8 @@
 			<column name="PERM_ID" value="KFS10405"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		-->
+		
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10438"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-215"/>
@@ -4121,6 +4201,9 @@
 			<column name="PERM_ID" value="KFS10451"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10473"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-234"/>
@@ -4135,6 +4218,8 @@
 			<column name="PERM_ID" value="KFS10470"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		-->
+		
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10507"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-252"/>
@@ -4142,6 +4227,9 @@
 			<column name="PERM_ID" value="KFS10503"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10512"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-253"/>
@@ -4156,6 +4244,8 @@
 			<column name="PERM_ID" value="KFS10513"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		-->
+		
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10521"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-256"/>
@@ -4373,6 +4463,9 @@
 			<column name="PERM_ID" value="KFS10722"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10729"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-308"/>
@@ -4380,6 +4473,8 @@
 			<column name="PERM_ID" value="KFS10723"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		-->
+		
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10732"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-309"/>
@@ -4422,6 +4517,9 @@
 			<column name="PERM_ID" value="KFS10312"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10741"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-315"/>
@@ -4450,6 +4548,8 @@
 			<column name="PERM_ID" value="KFS10298"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		-->
+		
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10745"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-319"/>
@@ -4457,6 +4557,9 @@
 			<column name="PERM_ID" value="KFS10735"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10749"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-320"/>
@@ -4464,6 +4567,8 @@
 			<column name="PERM_ID" value="KFS10746"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		-->
+		
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10750"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-321"/>
@@ -4492,6 +4597,9 @@
 			<column name="PERM_ID" value="KFS10328"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10757"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-325"/>
@@ -4506,6 +4614,8 @@
 			<column name="PERM_ID" value="KFS10758"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		-->
+		
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10766"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-327"/>
@@ -4520,6 +4630,9 @@
 			<column name="PERM_ID" value="KFS10767"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10771"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-329"/>
@@ -4534,6 +4647,8 @@
 			<column name="PERM_ID" value="KFS10767"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		-->
+		
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10776"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-331"/>
@@ -4548,6 +4663,9 @@
 			<column name="PERM_ID" value="KFS10773"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10778"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-333"/>
@@ -4555,6 +4673,8 @@
 			<column name="PERM_ID" value="KFS10773"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		-->
+		
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10782"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-334"/>
@@ -4569,6 +4689,9 @@
 			<column name="PERM_ID" value="KFS10779"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10784"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-336"/>
@@ -4576,6 +4699,8 @@
 			<column name="PERM_ID" value="KFS10779"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		-->
+		
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10789"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-337"/>
@@ -4604,6 +4729,9 @@
 			<column name="PERM_ID" value="KFS10746"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10801"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-341"/>
@@ -4611,6 +4739,8 @@
 			<column name="PERM_ID" value="KFS10798"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		-->
+		
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10802"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-342"/>
@@ -4646,6 +4776,9 @@
 			<column name="PERM_ID" value="KFS10804"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10809"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-347"/>
@@ -4653,6 +4786,8 @@
 			<column name="PERM_ID" value="KFS10804"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		-->
+		
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10810"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-348"/>
@@ -4681,6 +4816,9 @@
 			<column name="PERM_ID" value="KFS10811"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10815"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-352"/>
@@ -4688,6 +4826,8 @@
 			<column name="PERM_ID" value="KFS10811"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		-->
+		
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10816"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-353"/>
@@ -4716,6 +4856,9 @@
 			<column name="PERM_ID" value="KFS10821"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		
+		<!-- Commented out as there is no UA Specific Role to assign this permission per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10826"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-358"/>
@@ -4723,6 +4866,8 @@
 			<column name="PERM_ID" value="KFS10821"/>
 			<column name="ACTV_IND" value="Y"/>
 		</insert>
+		-->
+		
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10827"/>
 			<column name="OBJ_ID" value="KFS-TEM-ROLE-PERM-359"/>

--- a/src/main/resources/upgrade-files/5.2.2_5.3/rice_server/kim_upgrade.xml
+++ b/src/main/resources/upgrade-files/5.2.2_5.3/rice_server/kim_upgrade.xml
@@ -43,38 +43,42 @@
             <column name="ATTR_VAL" value="lastInventoryDateUpdateButton" />
         </insert>
 
+		<!-- Changed ROLE_ID from 34 to 10429 per UAF-936 -->
         <insert tableName="KRIM_ROLE_PERM_T">
             <column name="ROLE_PERM_ID" value="KFS10830" />
             <column name="OBJ_ID" value="KFS-ROLE-PERM-360" />
             <column name="VER_NBR" value="1" />
-            <column name="ROLE_ID" value="34" />
+            <column name="ROLE_ID" value="10429" />
             <column name="PERM_ID" value="KFS10828" />
             <column name="ACTV_IND" value="Y" />
         </insert>
 
+		<!-- Changed ROLE_ID from 35 to 10429 per UAF-936 -->
         <insert tableName="KRIM_ROLE_PERM_T">
             <column name="ROLE_PERM_ID" value="KFS10831" />
             <column name="OBJ_ID" value="KFS-ROLE-PERM-361" />
             <column name="VER_NBR" value="1" />
-            <column name="ROLE_ID" value="35" />
+            <column name="ROLE_ID" value="10429" />
             <column name="PERM_ID" value="KFS10828" />
             <column name="ACTV_IND" value="Y" />
         </insert>
 
+		<!-- Changed ROLE_ID from 46 to 10429 per UAF-936 -->
         <insert tableName="KRIM_ROLE_PERM_T">
             <column name="ROLE_PERM_ID" value="KFS10832" />
             <column name="OBJ_ID" value="KFS-ROLE-PERM-362" />
             <column name="VER_NBR" value="1" />
-            <column name="ROLE_ID" value="46" />
+            <column name="ROLE_ID" value="10429" />
             <column name="PERM_ID" value="KFS10828" />
             <column name="ACTV_IND" value="Y" />
         </insert>
 
+		<!-- Changed ROLE_ID from 5 to 10429 per UAF-936 -->
         <insert tableName="KRIM_ROLE_PERM_T">
             <column name="ROLE_PERM_ID" value="KFS10833" />
             <column name="OBJ_ID" value="KFS-ROLE-PERM-363" />
             <column name="VER_NBR" value="1" />
-            <column name="ROLE_ID" value="5" />
+            <column name="ROLE_ID" value="10429" />
             <column name="PERM_ID" value="KFS10828" />
             <column name="ACTV_IND" value="Y" />
         </insert>
@@ -114,6 +118,8 @@
 			<column name="ATTR_VAL" value="extractNow" />
 		</insert>
 		
+		<!-- Commented out as there is no UA specific role per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="10837" />
 			<column name="OBJ_ID" value="KFS-ROLE-PERM-364" />
@@ -121,7 +127,8 @@
 			<column name="ROLE_ID" valueNumeric="12" />
 			<column name="PERM_ID" value="KFS10834" />
 			<column name="ACTV_IND" value="N" />
-		</insert>		
+		</insert>	
+		-->
 	</changeSet>	
 	
 	<changeSet author="KFS53" id="KFSCNTRB-1793">
@@ -548,55 +555,126 @@
             <column name="ATTR_VAL" value="vendorHeader.vendorForeignTaxId" />
         </insert>
 
+		<!-- Changed ROLE_ID from 49 to 10403 per UAF-936 -->
         <insert tableName="KRIM_ROLE_PERM_T">
             <column name="ROLE_PERM_ID" value="KFS10880" />
             <column name="OBJ_ID" value="KFS-ROLE-PERM-365" />
             <column name="VER_NBR" value="1" />
-            <column name="ROLE_ID" value="49" />
+            <column name="ROLE_ID" value="10403" />
             <column name="PERM_ID" value="KFS10868" />
             <column name="ACTV_IND" value="Y" />
         </insert>
+		
+		<!-- Added ROLE_ID 56 per UAF-936 -->
+		<insert tableName="KRIM_ROLE_PERM_T">
+            <column name="ROLE_PERM_ID" value="KFS10888" />
+            <column name="OBJ_ID" value="KFS-ROLE-PERM-377" />
+            <column name="VER_NBR" value="1" />
+            <column name="ROLE_ID" value="56" />
+            <column name="PERM_ID" value="KFS10868" />
+            <column name="ACTV_IND" value="Y" />
+        </insert>
+		
+		<!-- Changed ROLE_ID from 49 to 10403 per UAF-936 -->
         <insert tableName="KRIM_ROLE_PERM_T">
             <column name="ROLE_PERM_ID" value="KFS10881" />
             <column name="OBJ_ID" value="KFS-ROLE-PERM-366" />
             <column name="VER_NBR" value="1" />
-            <column name="ROLE_ID" value="49" />
+            <column name="ROLE_ID" value="10403" />
             <column name="PERM_ID" value="KFS10869" />
             <column name="ACTV_IND" value="Y" />
         </insert>
+		
+		<!-- Added ROLE_ID 56 per UAF-936 -->
+		<insert tableName="KRIM_ROLE_PERM_T">
+            <column name="ROLE_PERM_ID" value="KFS10891" />
+            <column name="OBJ_ID" value="KFS-ROLE-PERM-379" />
+            <column name="VER_NBR" value="1" />
+            <column name="ROLE_ID" value="56" />
+            <column name="PERM_ID" value="KFS10869" />
+            <column name="ACTV_IND" value="Y" />
+        </insert>
+		
+		<!-- Changed ROLE_ID from 49 to 10403 per UAF-936 -->
         <insert tableName="KRIM_ROLE_PERM_T">
             <column name="ROLE_PERM_ID" value="KFS10882" />
             <column name="OBJ_ID" value="KFS-ROLE-PERM-367" />
             <column name="VER_NBR" value="1" />
-            <column name="ROLE_ID" value="49" />
+            <column name="ROLE_ID" value="10403" />
             <column name="PERM_ID" value="KFS10874" />
             <column name="ACTV_IND" value="Y" />
         </insert>
+		
+		<!-- Added ROLE_ID 56 per UAF-936 -->
+		<insert tableName="KRIM_ROLE_PERM_T">
+            <column name="ROLE_PERM_ID" value="KFS10892" />
+            <column name="OBJ_ID" value="KFS-ROLE-PERM-387" />
+            <column name="VER_NBR" value="1" />
+            <column name="ROLE_ID" value="56" />
+            <column name="PERM_ID" value="KFS10874" />
+            <column name="ACTV_IND" value="Y" />
+        </insert>
+		
+		<!-- Changed ROLE_ID from 49 to 10403 per UAF-936 -->
         <insert tableName="KRIM_ROLE_PERM_T">
             <column name="ROLE_PERM_ID" value="KFS10883" />
             <column name="OBJ_ID" value="KFS-ROLE-PERM-368" />
             <column name="VER_NBR" value="1" />
-            <column name="ROLE_ID" value="49" />
+            <column name="ROLE_ID" value="10403" />
             <column name="PERM_ID" value="KFS10875" />
             <column name="ACTV_IND" value="Y" />
         </insert>
+		
+		<!-- Added ROLE_ID 56 per UAF-936 -->
+		<insert tableName="KRIM_ROLE_PERM_T">
+            <column name="ROLE_PERM_ID" value="KFS10893" />
+            <column name="OBJ_ID" value="KFS-ROLE-PERM-388" />
+            <column name="VER_NBR" value="1" />
+            <column name="ROLE_ID" value="56" />
+            <column name="PERM_ID" value="KFS10875" />
+            <column name="ACTV_IND" value="Y" />
+        </insert>
+		
+		<!-- Changed ROLE_ID from 49 to 10403 per UAF-936 -->
         <insert tableName="KRIM_ROLE_PERM_T">
             <column name="ROLE_PERM_ID" value="KFS10886" />
             <column name="OBJ_ID" value="KFS-ROLE-PERM-369" />
             <column name="VER_NBR" value="1" />
-            <column name="ROLE_ID" value="49" />
+            <column name="ROLE_ID" value="10403" />
             <column name="PERM_ID" value="KFS10884" />
             <column name="ACTV_IND" value="Y" />
         </insert>
+		
+		<!-- Added ROLE_ID 56 per UAF-936 -->
+		<insert tableName="KRIM_ROLE_PERM_T">
+            <column name="ROLE_PERM_ID" value="KFS10894" />
+            <column name="OBJ_ID" value="KFS-ROLE-PERM-389" />
+            <column name="VER_NBR" value="1" />
+            <column name="ROLE_ID" value="56" />
+            <column name="PERM_ID" value="KFS10884" />
+            <column name="ACTV_IND" value="Y" />
+        </insert>
+		
+		<!-- Changed ROLE_ID from 49 to 10403 per UAF-936 -->
         <insert tableName="KRIM_ROLE_PERM_T">
             <column name="ROLE_PERM_ID" value="KFS10887" />
             <column name="OBJ_ID" value="KFS-ROLE-PERM-370" />
             <column name="VER_NBR" value="1" />
-            <column name="ROLE_ID" value="49" />
+            <column name="ROLE_ID" value="10403" />
             <column name="PERM_ID" value="KFS10885" />
             <column name="ACTV_IND" value="Y" />
         </insert>
-    	
+		
+		<!-- Added ROLE_ID 56 per UAF-936 -->
+    	<insert tableName="KRIM_ROLE_PERM_T">
+            <column name="ROLE_PERM_ID" value="KFS10898" />
+            <column name="OBJ_ID" value="KFS-ROLE-PERM-390" />
+            <column name="VER_NBR" value="1" />
+            <column name="ROLE_ID" value="56" />
+            <column name="PERM_ID" value="KFS10885" />
+            <column name="ACTV_IND" value="Y" />
+        </insert>
+		
     </changeSet>
     
 </databaseChangeLog>

--- a/src/main/resources/upgrade-files/5.3.2_5.4/rice_server/kim_upgrade.xml
+++ b/src/main/resources/upgrade-files/5.3.2_5.4/rice_server/kim_upgrade.xml
@@ -198,6 +198,9 @@
 			<column name="ATTR_VAL"
 				value="org.kuali.kfs.module.cg.web.struts.FederalFinancialReportAction" />
 		</insert>
+		
+		<!-- Commented out as there is no UA specific role per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10935" />
 			<column name="OBJ_ID" value="KFS-ROLE-PERM-372" />
@@ -206,6 +209,8 @@
 			<column name="ROLE_ID" value="38" />
 			<column name="ACTV_IND" value="Y" />
 		</insert>
+		-->
+		
 		<insert tableName="KRIM_PERM_T">
 			<column name="PERM_ID" value="KFS10909" />
 			<column name="OBJ_ID" value="KFS-PERM-132" />
@@ -226,6 +231,9 @@
 			<column name="ATTR_VAL"
 				value="org.kuali.kfs.module.cg.web.struts.TransmitContractsAndGrantsInvoicesLookupAction" />
 		</insert>
+		
+		<!-- Commented out as there is no UA specific role per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10936" />
 			<column name="OBJ_ID" value="KFS-ROLE-PERM-373" />
@@ -234,6 +242,8 @@
 			<column name="ROLE_ID" value="38" />
 			<column name="ACTV_IND" value="Y" />
 		</insert>
+		-->
+		
 		<insert tableName="KRIM_TYP_T">
 			<column name="KIM_TYP_ID" value="KFS10898" />
 			<column name="OBJ_ID" value="KFS-TYP-010" />
@@ -409,6 +419,9 @@
 			<column name="KIM_ATTR_DEFN_ID" valueNumeric="13" />
 			<column name="ATTR_VAL" value="DLTM" />
 		</insert>
+		
+		<!-- Commented out as there is no UA specific role per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10940" />
 			<column name="OBJ_ID" value="KFS-CGB-ROLE-PERM-007" />
@@ -417,6 +430,8 @@
 			<column name="PERM_ID" value="KFS10912" />
 			<column name="ACTV_IND" value="Y" />
 		</insert>
+		-->
+		
 		<insert tableName="KRIM_PERM_T">
 			<column name="PERM_ID" value="KFS10913" />
 			<column name="OBJ_ID" value="KFS-PERM-136" />
@@ -436,6 +451,9 @@
 			<column name="KIM_ATTR_DEFN_ID" valueNumeric="13" />
 			<column name="ATTR_VAL" value="DLTM" />
 		</insert>
+		
+		<!-- Commented out as there is no UA specific role per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10941" />
 			<column name="OBJ_ID" value="KFS-ROLE-PERM-378" />
@@ -444,6 +462,8 @@
 			<column name="PERM_ID" value="KFS10913" />
 			<column name="ACTV_IND" value="Y" />
 		</insert>
+		-->
+		
 		<insert tableName="KRIM_PERM_T">
 			<column name="PERM_ID" value="KFS10914" />
 			<column name="OBJ_ID" value="KFS-PERM-137" />
@@ -463,6 +483,9 @@
 			<column name="KIM_ATTR_DEFN_ID" valueNumeric="2" />
 			<column name="ATTR_VAL" value="org.kuali.kfs.module.ar.web.struts.AccountsReceivableDunningLetterTemplateUploadAction" />
 		</insert>
+		
+		<!-- Commented out as there is no UA specific role per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10942" />
 			<column name="OBJ_ID" value="KFS-CGB-ROLE-PERM-010" />
@@ -471,6 +494,8 @@
 			<column name="PERM_ID" value="KFS10914" />
 			<column name="ACTV_IND" value="Y" />
 		</insert>
+		-->
+		
 		<insert tableName="KRIM_PERM_T">
 			<column name="PERM_ID" value="KFS10915" />
 			<column name="OBJ_ID" value="KFS-PERM-138" />
@@ -490,6 +515,9 @@
 			<column name="KIM_ATTR_DEFN_ID" value="13" />
 			<column name="ATTR_VAL" value="LCR" />
 		</insert>
+		
+		<!-- Commented out as there is no UA specific role per UAF-936 -->
+		<!--
 		<insert tableName="KRIM_ROLE_PERM_T">
 			<column name="ROLE_PERM_ID" value="KFS10943" />
 			<column name="OBJ_ID" value="KFS-ROLE-PERM-380" />
@@ -498,6 +526,8 @@
 			<column name="ROLE_ID" value="44" />
 			<column name="ACTV_IND" value="Y" />
 		</insert>
+		-->
+		
 		<insert tableName="KRIM_PERM_T">
 			<column name="PERM_ID" value="KFS10916" />
 			<column name="OBJ_ID" value="KFS-PERM-139" />


### PR DESCRIPTION
Updated upgrade scripts. Commented out lines where the permission was being assigned to a foundation role and there is no UA Specific role at this time.  Updated the foundation role_id to the UA specific role.

Updated both the normal xml file and the "mod" xml files.