### PR TITLE
UAF-2404 Adds FUNDS_TYPE_CD column to the Account table (CA_ACCOUNT_T…

### DIFF
--- a/src/main/resources/kfsdbupgrade.properties
+++ b/src/main/resources/kfsdbupgrade.properties
@@ -72,7 +72,7 @@ files-5.3.1_5.3.2=rice_server/parameter_updates.xml,db/rice-client-script.xml,db
 files-5.3.2_5.4=rice_server/rice-server-script.xml,rice_server/kew_upgrade.xml,rice_server/kim_upgrade.xml,rice_server/parameter_updates.xml,db/rice-client-script.xml,db/master-structure-script.xml,db/master-constraint-script.xml,db/master-data-script.xml
 files-5.4_5-4.1=
 files-5.4.1_6.0=rice_server/rice-server-script.xml,rice_server/kew_upgrade.xml,rice_server/kim_upgrade.xml,rice_server/parameter_updates.xml,db/rice-client-script.xml,db/master-structure-script.xml,db/master-constraint-script.xml,db/master-data-script.xml
-files-post-upgrade=sql/kfs-public-synonyms.sql,sql/misc.sql,sql/kim_to_ldap_mapping_params.sql,sql/missing_components.sql,sql/kim_updates.sql,sql/kfs-indexes.sql
+files-post-upgrade=sql/kfs-public-synonyms.sql,sql/misc.sql,sql/kim_to_ldap_mapping_params.sql,sql/missing_components.sql,sql/kim_updates.sql,sql/kfs-indexes.sql,sql/liquibase_upgrade.sql,sql/ca_account_ext_t_migration.sql
 
 # logging information
 output-log-file-name=/var/jenkins_home/uaf/dbupgrade/logs/kfs-database-upgrade.log

--- a/src/main/resources/upgrade-files/post-upgrade/sql/ca_account_ext_t_migration.sql
+++ b/src/main/resources/upgrade-files/post-upgrade/sql/ca_account_ext_t_migration.sql
@@ -1,0 +1,13 @@
+-- =========================================================================================
+-- Adds FUNDS_TYPE_CD column to the Account table (CA_ACCOUNT_T) and then copies the funds 
+-- type code values from the Account Extension table (CA_ACCOUNT_EXT_T) to the Account table 
+-- because the Account Extension table will no longer be used in KFS 6.0  (UAF-2404) 
+-- =========================================================================================
+ALTER TABLE CA_ACCOUNT_T ADD FUNDS_TYPE_CD VARCHAR(3);
+ALTER TABLE CA_ACCOUNT_T ADD FOREIGN KEY (FUNDS_TYPE_CD) REFERENCES CA_SOURCE_OF_FUNDS_T(FUNDS_TYPE_CD);
+
+UPDATE CA_ACCOUNT_T A
+SET A.FUNDS_TYPE_CD = (
+SELECT B.FUNDS_TYPE_CD
+FROM CA_ACCOUNT_EXT_T B
+WHERE B.FIN_COA_CD = A.FIN_COA_CD AND B.ACCOUNT_NBR = A.ACCOUNT_NBR);


### PR DESCRIPTION
…) and then copies the funds type code values from the Account Extension table (CA_ACCOUNT_EXT_T) to the Account table because the Account Extension table will no longer be used in KFS 6.0