### PR TITLE
UAF-2070 : Add 'Lookup Records' Permission to the KFS-PDP UA Check Control Role in DB Upgrade Script. 

### DIFF
--- a/src/main/resources/kfsdbupgrade.properties
+++ b/src/main/resources/kfsdbupgrade.properties
@@ -75,7 +75,7 @@ files-5.3.1_5.3.2=rice_server/parameter_updates.xml,db/rice-client-script.xml,db
 files-5.3.2_5.4=rice_server/rice-server-script.xml,rice_server/kew_upgrade.xml,rice_server/kim_upgrade.xml,rice_server/parameter_updates.xml,db/rice-client-script.xml,db/master-structure-script.xml,db/master-constraint-script.xml,db/master-data-script.xml
 files-5.4_5-4.1=
 files-5.4.1_6.0=db/rice-client-script.xml,db/master-structure-script.xml,db/master-constraint-script.xml,db/master-data-script.xml
-files-post-upgrade=sql/kim_to_ldap_mapping_params.sql,sql/missing_components.sql,sql/kim_updates.sql,sql/liquibase_upgrade.sql,sql/ca_account_ext_t_migration.sql,sql/update_phase_2_parameters.sql,sql/add_back_parameters_deleted.sql
+files-post-upgrade=sql/kim_to_ldap_mapping_params.sql,sql/missing_components.sql,sql/kim_updates.sql,sql/liquibase_upgrade.sql,sql/ca_account_ext_t_migration.sql,sql/update_phase_2_parameters.sql,sql/add_back_parameters_deleted.sql,sql/add_lookup_records_permission.sql
 
 # logging information
 output-log-file-name=/var/jenkins_home/uaf/dbupgrade/logs/kfs-database-upgrade.log

--- a/src/main/resources/upgrade-files/post-upgrade/sql/add_lookup_records_permission.sql
+++ b/src/main/resources/upgrade-files/post-upgrade/sql/add_lookup_records_permission.sql
@@ -1,0 +1,4 @@
+-- =============================================================================================================
+-- (UAF-2070) Add "Lookup Records" Permission to the KFS-PDP UA Check Control Role in DB Upgrade Script (UAF-92)
+-- =============================================================================================================
+insert into kulowner.KRIM_ROLE_PERM_T (ROLE_PERM_ID, OBJ_ID, VER_NBR, ROLE_ID, PERM_ID, ACTV_IND) VALUES (KRIM_ROLE_PERM_ID_S.nextval, sys_guid(), '1', '10430', 'KFSMI6886-PRM2', 'Y');


### PR DESCRIPTION
UAF-2070 : Add 'Lookup Records' Permission to the KFS-PDP UA Check Control Role in DB Upgrade Script. Added 'post-upgrade/sql/add_lookup_records_permission.sql' file to Add 'Lookup Records' Permission to the KFS-PDP UA Check Control Role to table "KRIM_ROLE_PERM_T"; modified file '/kfsdbupgrade/src/main/resources/kfsdbupgrade.properties' to invoke it.