### PR TITLE
UAF-2321 : Inactivate Redundant Role 11053 in Upgrade Scripts.

### DIFF
--- a/src/main/resources/kfsdbupgrade.properties
+++ b/src/main/resources/kfsdbupgrade.properties
@@ -75,7 +75,7 @@ files-5.3.1_5.3.2=rice_server/parameter_updates.xml,db/rice-client-script.xml,db
 files-5.3.2_5.4=rice_server/rice-server-script.xml,rice_server/kew_upgrade.xml,rice_server/kim_upgrade.xml,rice_server/parameter_updates.xml,db/rice-client-script.xml,db/master-structure-script.xml,db/master-constraint-script.xml,db/master-data-script.xml
 files-5.4_5-4.1=
 files-5.4.1_6.0=db/rice-client-script.xml,db/master-structure-script.xml,db/master-constraint-script.xml,db/master-data-script.xml
-files-post-upgrade=sql/kim_to_ldap_mapping_params.sql,sql/missing_components.sql,sql/kim_updates.sql,sql/liquibase_upgrade.sql,sql/ca_account_ext_t_migration.sql,sql/update_phase_2_parameters.sql,sql/add_back_parameters_deleted.sql,sql/add_lookup_records_permission.sql
+files-post-upgrade=sql/kim_to_ldap_mapping_params.sql,sql/missing_components.sql,sql/kim_updates.sql,sql/liquibase_upgrade.sql,sql/ca_account_ext_t_migration.sql,sql/update_phase_2_parameters.sql,sql/add_back_parameters_deleted.sql,sql/add_lookup_records_permission.sql,sql/inactivate_role_11053.sql
 
 # logging information
 output-log-file-name=/var/jenkins_home/uaf/dbupgrade/logs/kfs-database-upgrade.log

--- a/src/main/resources/upgrade-files/post-upgrade/sql/inactivate_role_11053.sql
+++ b/src/main/resources/upgrade-files/post-upgrade/sql/inactivate_role_11053.sql
@@ -1,0 +1,6 @@
+-- =============================================================================================================
+-- (UAF-2321) Inactivate Redundant Role 11053 <Exclude Single Actor Separation Of Duties> in Upgrade Scripts (UAF-92)
+-- =============================================================================================================
+update kulowner.KRIM_ROLE_T set ACTV_IND = 'N' where ROLE_ID ='11053';
+update kulowner.KRIM_ROLE_RSP_T set ACTV_IND = 'N'  where ROLE_ID ='11053';
+update kulowner.KRIM_ROLE_MBR_T set ACTV_TO_DT = '01-JAN-16' where ROLE_ID = '11053';


### PR DESCRIPTION
UAF-2321 : Inactivate Redundant Role 11053 <Exclude Single Actor Separation Of Duties> in Upgrade Scripts. Created SQL script 'post-upgrade/sql/inactivate_role_11053.sql' file to; Update Role 11053: 1) inactivate the role, 2) inactivate responsibility 92 on the role, 3) inactivate Role 56 on the role by adding a current end date.