### PR TITLE
UAF-2739 : Activate Responsibility 49 to Role 10403 (UA FSO AP Tax Specialists)

### DIFF
--- a/src/main/resources/kfsdbupgrade.properties
+++ b/src/main/resources/kfsdbupgrade.properties
@@ -75,7 +75,7 @@ files-5.3.1_5.3.2=rice_server/parameter_updates.xml,db/rice-client-script.xml,db
 files-5.3.2_5.4=rice_server/rice-server-script.xml,rice_server/kew_upgrade.xml,rice_server/kim_upgrade.xml,rice_server/parameter_updates.xml,db/rice-client-script.xml,db/master-structure-script.xml,db/master-constraint-script.xml,db/master-data-script.xml
 files-5.4_5-4.1=
 files-5.4.1_6.0=db/rice-client-script.xml,db/master-structure-script.xml,db/master-constraint-script.xml,db/master-data-script.xml
-files-post-upgrade=sql/kim_to_ldap_mapping_params.sql,sql/missing_components.sql,sql/kim_updates.sql,sql/liquibase_upgrade.sql,sql/ca_account_ext_t_migration.sql,sql/update_phase_2_parameters.sql,sql/add_back_parameters_deleted.sql,sql/add_lookup_records_permission.sql,sql/inactivate_role_11053.sql,sql/update_system_enhancement_parameters.sql,sql/update_requisition_source.sql
+files-post-upgrade=sql/kim_to_ldap_mapping_params.sql,sql/missing_components.sql,sql/kim_updates.sql,sql/liquibase_upgrade.sql,sql/ca_account_ext_t_migration.sql,sql/update_phase_2_parameters.sql,sql/add_back_parameters_deleted.sql,sql/add_lookup_records_permission.sql,sql/inactivate_role_11053.sql,sql/update_system_enhancement_parameters.sql,sql/update_requisition_source.sql,sql/add_responsibility_49_role_10403.sql
 
 # logging information
 output-log-file-name=/var/jenkins_home/uaf/dbupgrade/logs/kfs-database-upgrade.log

--- a/src/main/resources/upgrade-files/post-upgrade/sql/add_responsibility_49_role_10403.sql
+++ b/src/main/resources/upgrade-files/post-upgrade/sql/add_responsibility_49_role_10403.sql
@@ -1,0 +1,8 @@
+-- =======================================================================================================================
+-- UAF-2739 : Activate Responsibility 49 and Add Responsibility 49 (Review KFS Tax) to Role 10403 (UA FSO AP Tax Specialists). Subtask of (UAF-92)
+-- =======================================================================================================================
+--The below SQL is to delete the extra 5 detail values that came over from 3.0:
+DELETE FROM KULOWNER.KRIM_RSP_ATTR_DATA_T WHERE ATTR_DATA_ID IN ('165178','157','158','159','160');
+
+--The responsibility is actually active in 6.0, but the responsibility role connection in the KRIM_ROLE_RSP_T table is inactive. The below SQL is to make that active:
+UPDATE KULOWNER.KRIM_ROLE_RSP_T SET ACTV_IND = 'Y' WHERE ROLE_ID='10403';


### PR DESCRIPTION
UAF-2739 : Activate Responsibility 49 and Add Responsibility 49 (Review KFS Tax) to Role 10403 (UA FSO AP Tax Specialists).  Added SQL script file 'post-upgrade/sql/add_responsibility_49_role_10403.sql' containing delete/update scripts and modified file '/kfsdbupgrade/src/main/resources/kfsdbupgrade.properties' to invoke it.