### PR TITLE
UAFAWS-98 - Removing decryption function. Making encryption key parameterized.

### DIFF
--- a/src/main/resources/flowdown-files/sql/kfs6-env-flowdown.sql
+++ b/src/main/resources/flowdown-files/sql/kfs6-env-flowdown.sql
@@ -116,12 +116,11 @@ where grp_id in
 --   For the Tax Id Types that are set to NONE, it leaves it as is (so it allows blank values)
 -- !!! Note: KULOWNER needs permission to run the DBMS_CRYPTO package for ENCRYPTING the dummy numbers
 -- ====================================================================================================================
--- Create/Update the DES Encrypt/Decrypt functions in the DB
+-- Create/Update the DES Encrypt function in the DB
 CREATE OR REPLACE
-FUNCTION          DES_ENCRYPT (p_plainText VARCHAR2) RETURN VARCHAR2
+FUNCTION          DES_ENCRYPT (p_plainText VARCHAR2, encryption_key RAW) RETURN VARCHAR2
 IS
     encryptedValue      VARCHAR2(255);
-    encryption_key      RAW (8) := ('EC80BAE30EA40101');
     encryption_type     PLS_INTEGER := dbms_crypto.ENCRYPT_DES + DBMS_CRYPTO.CHAIN_ECB + DBMS_CRYPTO.PAD_PKCS5;
     
 BEGIN
@@ -134,33 +133,17 @@ BEGIN
 END;
 /
 
-CREATE OR REPLACE
-FUNCTION          DES_DECRYPT (p_encodedText VARCHAR2) RETURN VARCHAR2
-IS
-    decryptedValue      RAW(255);
-    encryption_key      RAW (8) := ('EC80BAE30EA40101');
-    encryption_type     PLS_INTEGER := dbms_crypto.ENCRYPT_DES + DBMS_CRYPTO.CHAIN_ECB + DBMS_CRYPTO.PAD_PKCS5;
-    
-BEGIN
-	decryptedValue:= dbms_crypto.DECRYPT(
-    src => UTL_ENCODE.base64_decode( UTL_I18N.STRING_TO_RAW( p_encodedText,'utf8')),
-    typ => encryption_type,
-    key => encryption_key
-  );
-  RETURN UTL_I18N.RAW_TO_CHAR( decryptedValue, 'utf8');
-END;
-/
-
 -- NEW: 9000000000000 + ROW# -  for account numbers 
-UPDATE fp_dv_ach_t set dv_payee_acct_nbr = DES_ENCRYPT( ROWNUM + 9000000000000 );
-UPDATE KULOWNER.fs_pmt_src_wire_trnfr_t set payee_acct_nbr = DES_ENCRYPT( ROWNUM + 9000000000000 );
-UPDATE pdp_ach_acct_nbr_t set ach_bnk_acct_nbr = DES_ENCRYPT( ROWNUM + 9000000000000 );
-UPDATE pdp_payee_ach_acct_t set bnk_acct_nbr = DES_ENCRYPT( ROWNUM + 9000000000000 );
+
+UPDATE fp_dv_ach_t set dv_payee_acct_nbr = DES_ENCRYPT( ROWNUM + 9000000000000 , '${ENCRYPTION_KEY}');
+UPDATE KULOWNER.fs_pmt_src_wire_trnfr_t set payee_acct_nbr = DES_ENCRYPT( ROWNUM + 9000000000000 , '${ENCRYPTION_KEY}');
+UPDATE pdp_ach_acct_nbr_t set ach_bnk_acct_nbr = DES_ENCRYPT( ROWNUM + 9000000000000 , '${ENCRYPTION_KEY}');
+UPDATE pdp_payee_ach_acct_t set bnk_acct_nbr = DES_ENCRYPT( ROWNUM + 9000000000000 , '${ENCRYPTION_KEY}');
 
 -- NEW: 900000000 + ROW# - for tax id numbers that are not of type NONE
-UPDATE pur_vndr_hdr_t set vndr_us_tax_nbr = DES_ENCRYPT( ROWNUM + 900000000 ) where vndr_tax_typ_cd != 'NONE';
-UPDATE pur_vndr_tax_chg_t set vndr_prev_tax_nbr = DES_ENCRYPT( ROWNUM + 899999999 ) where vndr_prev_tax_typ_cd != 'NONE';
-UPDATE tax_payee_t set hdr_vndr_tax_nbr = DES_ENCRYPT( ROWNUM + 900000000 );
+UPDATE pur_vndr_hdr_t set vndr_us_tax_nbr = DES_ENCRYPT( ROWNUM + 900000000 , '${ENCRYPTION_KEY}') where vndr_tax_typ_cd != 'NONE';
+UPDATE pur_vndr_tax_chg_t set vndr_prev_tax_nbr = DES_ENCRYPT( ROWNUM + 899999999 , '${ENCRYPTION_KEY}') where vndr_prev_tax_typ_cd != 'NONE';
+UPDATE tax_payee_t set hdr_vndr_tax_nbr = DES_ENCRYPT( ROWNUM + 900000000 , '${ENCRYPTION_KEY}');
 
 --OLD:
 -- update fp_dv_ach_t set dv_payee_acct_nbr = 'r+181z6uNTJrgbJPn0ljGA==';
@@ -170,7 +153,6 @@ UPDATE tax_payee_t set hdr_vndr_tax_nbr = DES_ENCRYPT( ROWNUM + 900000000 );
 -- update pur_vndr_hdr_t set vndr_us_tax_nbr = 'r+181z6uNTIc3lalnjPKpA==';
 -- update pur_vndr_tax_chg_t set vndr_prev_tax_nbr = 'r+181z6uNTIc3lalnjPKpA==';
 -- update tax_payee_t set hdr_vndr_tax_nbr = 'r+181z6uNTIc3lalnjPKpA==';
-
 
 -- ====================================================================================================================
 -- 4) Add test ID kfs-test-sec9 (mbr_id# T000000000000005400) to ALL groups starting with UA PCRD.


### PR DESCRIPTION
Note: It is up to whatever calls the flowdown script (Jenkins job, human user) to hydrate the value for ${ENCRYPTION_KEY} safely.