### PR TITLE
UAF-4243 : Shorten Index names by shortening the Index name stub generated from a table name.

### DIFF
--- a/src/main/java/ua/utility/kfsdbupgrade/ForeignKeyReference.java
+++ b/src/main/java/ua/utility/kfsdbupgrade/ForeignKeyReference.java
@@ -105,7 +105,13 @@ public class ForeignKeyReference implements Comparable <ForeignKeyReference> {
 		StringBuilder retval = new StringBuilder(128);
 		retval.append(schemaName.toUpperCase());
 		retval.append(".");
-		retval.append(indexNameTemplate.replace("[table-name]", tableName).replace("{index}", "" + indx));
+		// Oracle before v 12.2 only allows identifiers upto 30 characters in length, so shorten index names
+		String shortTableName = tableName;
+		if (tableName.lastIndexOf("_T") == (tableName.length() - 2)) {
+			shortTableName = tableName.substring(0,tableName.length() - 2);
+		}
+		shortTableName = shortTableName.replace("_","");
+		retval.append(indexNameTemplate.replace("[table-name]", shortTableName).replace("{index}", "" + indx));
 		return retval.toString();
 	}
 

--- a/src/main/java/ua/utility/kfsdbupgrade/ForeignKeyReference.java
+++ b/src/main/java/ua/utility/kfsdbupgrade/ForeignKeyReference.java
@@ -105,13 +105,16 @@ public class ForeignKeyReference implements Comparable <ForeignKeyReference> {
 		StringBuilder retval = new StringBuilder(128);
 		retval.append(schemaName.toUpperCase());
 		retval.append(".");
-		// Oracle before v 12.2 only allows identifiers upto 30 characters in length, so shorten index names
-		String shortTableName = tableName;
+		// Oracle before v 12.2 only allows identifiers upto 30 characters in length, so shorten index names.
+		// Instead of using the table name as the index name stub use the table name with
+		// trailing "_T" (underscore T) removed and all "_"'s (underscores) removed as the index name stub.
+		// Thus the index name will be shorter but still correlate with the unmolested table name.
+		String shortIndexNameStub = tableName;
 		if (tableName.lastIndexOf("_T") == (tableName.length() - 2)) {
-			shortTableName = tableName.substring(0,tableName.length() - 2);
+			shortIndexNameStub = tableName.substring(0,tableName.length() - 2);
 		}
-		shortTableName = shortTableName.replace("_","");
-		retval.append(indexNameTemplate.replace("[table-name]", shortTableName).replace("{index}", "" + indx));
+		shortIndexNameStub = shortIndexNameStub.replace("_","");
+		retval.append(indexNameTemplate.replace("[table-name]", shortIndexNameStub).replace("{index}", "" + indx));
 		return retval.toString();
 	}
 

--- a/src/main/java/ua/utility/kfsdbupgrade/ForeignKeyReference.java
+++ b/src/main/java/ua/utility/kfsdbupgrade/ForeignKeyReference.java
@@ -110,7 +110,7 @@ public class ForeignKeyReference implements Comparable <ForeignKeyReference> {
 		// trailing "_T" (underscore T) removed and all "_"'s (underscores) removed as the index name stub.
 		// Thus the index name will be shorter but still correlate with the unmolested table name.
 		String shortIndexNameStub = tableName;
-		if (tableName.lastIndexOf("_T") == (tableName.length() - 2)) {
+		if (tableName.toLowerCase().endsWith("_t")) {
 			shortIndexNameStub = tableName.substring(0,tableName.length() - 2);
 		}
 		shortIndexNameStub = shortIndexNameStub.replace("_","");


### PR DESCRIPTION
UAF-4243 : ERROR ua.utility.kfsdbupgrade.App :: failed to create index:: ORA-00972: identifier is too long.  Oracle versions before 12.2 only allow identifiers upto 30 characters in length. So shortening Index names by removing unnecessary characters from the table name used to construct the Index name.