### PR TITLE
UAF-4237 : KFS_401_RESTORE_MISSING_RICE_SEQUENCES

### DIFF
--- a/src/main/resources/upgrade-files/4.0_4.1/db/01_structure/rice-client-structure.xml
+++ b/src/main/resources/upgrade-files/4.0_4.1/db/01_structure/rice-client-structure.xml
@@ -26,7 +26,7 @@
   			</and>
   		</not>
   	</preConditions>
-	<comment>Restore Sequences needed if running with a separate standalone Rice server.</comment>
+	<comment>Restore Sequences needed if running with a separate standalone Rice server. If PRECONDITION FAILED Below Then Sequence Already Exists So Skipped Creating it! If PRECONDITION SUCCEEDED Below Then Sequence Does Not Exist So Created it!</comment>
 	<createSequence sequenceName="KRSB_BAM_PARM_S" startValue="30000" />
 	<createSequence sequenceName="KRSB_BAM_S" startValue="30000" />
 	<createSequence sequenceName="KRSB_MSG_QUE_S" startValue="30000" />

--- a/src/main/resources/upgrade-files/4.0_4.1/db/01_structure/rice-client-structure.xml
+++ b/src/main/resources/upgrade-files/4.0_4.1/db/01_structure/rice-client-structure.xml
@@ -26,7 +26,7 @@
   			</and>
   		</not>
   	</preConditions>
-	<comment>Restore Sequences needed if running with a separate standalone Rice server. If PRECONDITION FAILED Below Then Sequence Already Exists So Skipped Creating it! If PRECONDITION SUCCEEDED Below Then Sequence Does Not Exist So Created it!</comment>
+	<comment>Restore Rice Sequences needed if running with a separate standalone Rice server. If   Not precondition failed   Below Then Sequence Already Exists So Skipped Creating it! If   Not precondition succeeded   Below Then Sequence Does Not Exist So Created it!</comment>
 	<createSequence sequenceName="KRSB_BAM_PARM_S" startValue="30000" />
 	<createSequence sequenceName="KRSB_BAM_S" startValue="30000" />
 	<createSequence sequenceName="KRSB_MSG_QUE_S" startValue="30000" />

--- a/src/main/resources/upgrade-files/4.0_4.1/db/01_structure/rice-client-structure.xml
+++ b/src/main/resources/upgrade-files/4.0_4.1/db/01_structure/rice-client-structure.xml
@@ -17,7 +17,6 @@
 <databaseChangeLog xmlns='http://www.liquibase.org/xml/ns/dbchangelog/1.9' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:schemaLocation='http://www.liquibase.org/xml/ns/dbchangelog/1.9 http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd'>
 
   <changeSet author="kfs" id="KFS_401_RESTORE_MISSING_RICE_SEQUENCES_oracle" failOnError="false" dbms="oracle">
-    <!-- Preconditions don't seem to be working right - hangs the build 
   	<preConditions onFail="MARK_RAN">
   		<not>
   			<and>
@@ -27,7 +26,6 @@
   			</and>
   		</not>
   	</preConditions>
-  	-->
 	<comment>Restore Sequences needed if running with a separate standalone Rice server.</comment>
 	<createSequence sequenceName="KRSB_BAM_PARM_S" startValue="30000" />
 	<createSequence sequenceName="KRSB_BAM_S" startValue="30000" />
@@ -35,7 +33,7 @@
   </changeSet>
 
   <changeSet author="kfs" id="KFS_401_RESTORE_MISSING_RICE_SEQUENCES_mysql" failOnError="false" dbms="mysql">
-    <!--
+    <!--  Preconditions don't seem to be working right - hangs the build
   	<preConditions onFail="MARK_RAN">
   		<not>
   			<and>


### PR DESCRIPTION
UAF-4237 : KFS_401_RESTORE_MISSING_RICE_SEQUENCES. Uncommented Liquibase <preconditions > clause in '\kfsdbupgrade\src\main\resources\upgrade-files\4.0_4.1\db\01_structure\rice-client-structure.xml' to check whether sequence exists before trying to create it again. Modified Liquibase comment for greater log clarity.