### PR TITLE
UAF-5089 : DBUpgrade: Please investigate Excessive WARN: Document has classname in contents that should have been mapped on 07/17/17.

### DIFF
--- a/src/main/java/ua/utility/kfsdbupgrade/MaintainableXMLConversionServiceImpl.java
+++ b/src/main/java/ua/utility/kfsdbupgrade/MaintainableXMLConversionServiceImpl.java
@@ -258,6 +258,16 @@ public class MaintainableXMLConversionServiceImpl {
 		xml = xml + "<" + MAINTENANCE_ACTION_ELEMENT_NAME + ">" + maintenanceAction + "</"
 				+ MAINTENANCE_ACTION_ELEMENT_NAME + ">";
 
+		// replace classnames not updated so far that were captured by smoke test below
+		for (String className : classNameRuleMap.keySet()) {
+			if (xml.contains("active defined-in=\"" + className + "\"")) {
+				LOGGER.trace("Replacing active defined-in= attribute: " + className + " with: "
+						+ classNameRuleMap.get(className));
+				xml = xml.replace("active defined-in=\"" + className + "\"",
+						"active defined-in=\"" + classNameRuleMap.get(className) + "\"");
+			}
+		}
+
 		// investigative logging, still useful as a smoke test
 		for (String oldClassName : classNameRuleMap.keySet()) {
 			if (xml.contains(oldClassName)) {

--- a/src/main/java/ua/utility/kfsdbupgrade/MaintainableXMLConversionServiceImpl.java
+++ b/src/main/java/ua/utility/kfsdbupgrade/MaintainableXMLConversionServiceImpl.java
@@ -261,7 +261,7 @@ public class MaintainableXMLConversionServiceImpl {
 		// replace classnames not updated so far that were captured by smoke test below
 		for (String className : classNameRuleMap.keySet()) {
 			if (xml.contains("active defined-in=\"" + className + "\"")) {
-				LOGGER.trace("Replacing active defined-in= attribute: " + className + " with: "
+				LOGGER.info("Replacing active defined-in= attribute: " + className + " with: "
 						+ classNameRuleMap.get(className));
 				xml = xml.replace("active defined-in=\"" + className + "\"",
 						"active defined-in=\"" + classNameRuleMap.get(className) + "\"");


### PR DESCRIPTION
UAF-5089 : DBUpgrade: Please investigate Excessive WARN: Document has classname in contents that should have been mapped on 07/17/17.  Added code to 'ua.utility.kfsdbupgrade.MaintainableXMLConversionServiceImpl.transformSection()' to update old classnames not updated so far that occur in '<active defined-in=' tags.