### PR TITLE
UAF-5099 - Changing how GEC bootstrap determines fiscal year; add IDE file to gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@
 .idea
 kfsdbupgrade.log
 kfs-database-upgrade.log
+kfsdbupgrade.iml
 

--- a/src/main/resources/upgrade-files/post-upgrade/sql/UAF-3849-bootstrap_new_gec_relationship_data.sql
+++ b/src/main/resources/upgrade-files/post-upgrade/sql/UAF-3849-bootstrap_new_gec_relationship_data.sql
@@ -123,8 +123,8 @@ select gle.ENTRY_ID, gecd.FDOC_NBR, lines.FDOC_REF_NBR, lines.FDOC_LN_TYP_CD, li
         on gecd.FDOC_NBR = lines.FDOC_NBR
     inner join GL_ENTRY_T gle
         on gle.UNIV_FISCAL_YR in (
-            (select to_char(sysdate, 'YYYY') from dual),
-            (select to_char(sysdate, 'YYYY')-1 from dual)
+            (select UNIV_FISCAL_YR from SH_UNIV_DATE_T where UNIV_DT = trunc(sysdate)),
+            (select (UNIV_FISCAL_YR - 1) from sh_univ_date_t where UNIV_DT = trunc(sysdate))
         )
         and lines.FDOC_POST_YR     = gle.UNIV_FISCAL_YR
         and lines.FIN_COA_CD       = gle.FIN_COA_CD


### PR DESCRIPTION
This changes the 'naive' way of pulling fiscal year to instead use a special table for this purpose. This ensures all legacy data that should be considered, actually is being considered.