### PR TITLE
UAF-5455 : Modify Backdoor Access for KFS 6 & 7 Environments - tholan and tgonzale.

### DIFF
--- a/src/main/resources/flowdown-files/sql/kfs6-env-flowdown.sql
+++ b/src/main/resources/flowdown-files/sql/kfs6-env-flowdown.sql
@@ -1027,3 +1027,7 @@ insert into krim_role_mbr_t ( role_mbr_id, ver_nbr, obj_id, role_id, mbr_id, mbr
 insert into krim_role_mbr_t ( role_mbr_id, ver_nbr, obj_id, role_id, mbr_id, mbr_typ_cd) values (KRIM_ROLE_MBR_ID_S.NEXTVAL, 1, SYS_GUID(), (select role_id from krim_role_t where role_nm='Back Door Login'), '101470899535', 'P');
 -- pprokop
 insert into krim_role_mbr_t ( role_mbr_id, ver_nbr, obj_id, role_id, mbr_id, mbr_typ_cd) values (KRIM_ROLE_MBR_ID_S.NEXTVAL, 1, SYS_GUID(), (select role_id from krim_role_t where role_nm='Back Door Login'), '100917596865', 'P');
+-- tgonzale
+insert into krim_role_mbr_t ( role_mbr_id, ver_nbr, obj_id, role_id, mbr_id, mbr_typ_cd) values (KRIM_ROLE_MBR_ID_S.NEXTVAL, 1, SYS_GUID(), (select role_id from krim_role_t where role_nm='Back Door Login'), '119769966165', 'P');
+-- tholan
+insert into krim_role_mbr_t ( role_mbr_id, ver_nbr, obj_id, role_id, mbr_id, mbr_typ_cd) values (KRIM_ROLE_MBR_ID_S.NEXTVAL, 1, SYS_GUID(), (select role_id from krim_role_t where role_nm='Back Door Login'), '120904270847', 'P');


### PR DESCRIPTION
UAF-5455 : Modify Backdoor Access for KFS 6 & 7 Environments - tholan and tgonzale. Added KFS 6 DB backdoor access permission SQL inserts for Tara J Gonzales (tgonzale) and Tabatha M Holan (tholan) to kfsdbupgrade file 'flowdown-files/sql/kfs6-env-flowdown.sql'.