### PR TITLE
UAF-4657 - Adding missing parent doc type for kc-kfs module.

### DIFF
--- a/src/main/resources/upgrade-files/5.3.2_5.4/workflow/workflow_document_upgrades.xml
+++ b/src/main/resources/upgrade-files/5.3.2_5.4/workflow/workflow_document_upgrades.xml
@@ -1065,6 +1065,11 @@
 			</routeNodes>
 		</documentType>
 		<documentType>
+			<name>KCSM</name>
+			<label>Kuali Coeus Integration Simple Maintenance Documents</label>
+			<parent>FSSM</parent>
+		</documentType>
+		<documentType>
 			<name>
 				BFM
 			</name>


### PR DESCRIPTION
This should correct the errors generated by the child workflow referencing its-not-loaded-yet parent.