### PR TITLE
UAF-5698 : Investigate Errors for KFS 3 Shipping Docs Migrated to KFS 7. 

### DIFF
--- a/src/main/java/ua/utility/kfsdbupgrade/MaintainableXMLConversionServiceImpl.java
+++ b/src/main/java/ua/utility/kfsdbupgrade/MaintainableXMLConversionServiceImpl.java
@@ -289,6 +289,17 @@ public class MaintainableXMLConversionServiceImpl {
 			}
 		}
 
+		// replace classnames not updated so far that were captured by smoke test below
+		// Using context specific replacements in case match replacement pairs entered are too generic
+		for (String className : classNameRuleMap.keySet()) {
+			if (xml.contains("maintainableImplClass=\"" + className + "\"")) {
+				LOGGER.info("Replacing maintainableImplClass= attribute: " + className + " with: "
+						+ classNameRuleMap.get(className) + " at docid= " + docid);
+				xml = xml.replace("maintainableImplClass=\"" + className + "\"",
+						"maintainableImplClass=\"" + classNameRuleMap.get(className) + "\"");
+			}
+		}
+
 		// investigative logging, still useful as a smoke test
 		for (String oldClassName : classNameRuleMap.keySet()) {
 			if (xml.contains(oldClassName)) {

--- a/src/main/resources/MaintainableXMLUpgradeRules.xml
+++ b/src/main/resources/MaintainableXMLUpgradeRules.xml
@@ -160,6 +160,10 @@
       <match>com.rsmart.kuali.kfs.prje.bo.PRJEBaseAccount</match>
       <replacement>edu.arizona.kfs.module.prje.businessobject.PRJEBaseAccount</replacement>
     </pattern>
+    <pattern>
+      <match>org.kuali.rice.kns.maintenance.KualiMaintainableImpl</match>
+      <replacement>org.kuali.kfs.sys.document.FinancialSystemMaintainable</replacement>
+    </pattern>
   </rule>
 
   <!-- Rules specifying any change in class properties.


### PR DESCRIPTION
UAF-5698 : Investigate Errors for KFS 3 Shipping Docs Migrated to KFS 7. Modified file 'MaintainableXMLUpgradeRules.xml' with old class 'org.kuali.rice.kns.maintenance.KualiMaintainableImpl' to  new class 'org.kuali.kfs.sys.document.FinancialSystemMaintainable' pattern. Modified file 'MaintainableXMLConversionServiceImpl.java' to replace classes in attribute 'maintainableImplClass='.