### PR TITLE
UAF-5917 : Correct KFSDBUpgrade XML closing tag replacement.

### DIFF
--- a/src/main/java/ua/utility/kfsdbupgrade/MaintainableXMLConversionServiceImpl.java
+++ b/src/main/java/ua/utility/kfsdbupgrade/MaintainableXMLConversionServiceImpl.java
@@ -283,8 +283,8 @@ public class MaintainableXMLConversionServiceImpl {
 		for (String className : classNameRuleMap.keySet()) {
 			if (xml.contains("</" + className + ">")) {
 				LOGGER.info("Replacing close tag: </" + className + "> with: </"
-						+ classNameRuleMap.get(className) + ">");
-				xml = xml.replace("</" + className + ">" + " at docid= " + docid ,
+						+ classNameRuleMap.get(className) + ">" + " at docid= " + docid);
+				xml = xml.replace("</" + className + ">",
 						"</" + classNameRuleMap.get(className) + ">");
 			}
 		}


### PR DESCRIPTION
UAF-5917 : Correct KFSDBUpgrade XML closing tag replacement. Corrected an error in  'ua.utility.kfsdbupgrade.MaintainableXMLConversionServiceImpl.transformSection' that was preventing replacement of closing tags eventhough opening tags were being replaced.