### PR TITLE
UAF-5951 Bug - Cannot open Account doc created in 3 in STG7

### DIFF
--- a/src/main/java/ua/utility/kfsdbupgrade/MaintainableXMLConversionServiceImpl.java
+++ b/src/main/java/ua/utility/kfsdbupgrade/MaintainableXMLConversionServiceImpl.java
@@ -585,7 +585,7 @@ public class MaintainableXMLConversionServiceImpl implements MaintainableXmlConv
         
         return oldXML;
     }
-
+    
 	/**
 	 * Migrate any elements with the <code>class</code> containing
 	 * <code>PersonImpl</code> from the provided {@link Document} if there is a
@@ -648,27 +648,6 @@ public class MaintainableXMLConversionServiceImpl implements MaintainableXmlConv
 						tempNode.removeChild(child);
 					}
 				}
-				if (!(line1 == null || line1.isEmpty()) || !(line2 == null || line2.isEmpty())
-						|| !(line3 == null || line3.isEmpty()) || !(city == null || city.isEmpty())
-						|| !(stateProvinceCode == null || stateProvinceCode.isEmpty())
-						|| !(postalCode == null || postalCode.isEmpty())
-						|| !(countryCode == null || countryCode.isEmpty())) {
-					EntityAddressBo bo = new EntityAddressBo();
-					bo.setLine1(line1);
-					bo.setLine2(line2);
-					bo.setLine3(line3);
-					bo.setCity(city);
-					bo.setStateProvinceCode(stateProvinceCode);
-					bo.setPostalCode(postalCode);
-					bo.setCountryCode(countryCode);
-					EntityAddress address = EntityAddress.Builder.create(bo).build();
-
-					XStream xStream = new XStream(new DomDriver());
-					xStream.marshal(address, new DomWriter((Element) tempNode));
-				}
-				String newClassName = this.classNameRuleMap.get(personImplClassName);
-				Node classAttr = tempNode.getAttributes().getNamedItem("class");
-				classAttr.setNodeValue(newClassName);
             }
         } catch (XPathExpressionException e) {
 			LOGGER.error("XPathException encountered: ", e);


### PR DESCRIPTION
ACCT maintenance doc has EntityAddress change which is a reference object from Person. The way original code creating new EntityAddressBo, marshaling and appending to ACCT maint xstream will append a EntityAddress to the end of stream of Account BO node which can't map to Account BO since Account BO has no direct reference to EntityAddress. The fix is to remove appending EntityAddressBo node from ACCT xml since it's not directly referenced from Account. It can be derived from Person BO still since it's referred from Person BO after unmarshalling.