### PR TITLE
UAF-5564 : KFS7 STG Receive a Conversion STE When Attempting to View Enroute/Legacy 3.0 CASM Documents.

### DIFF
--- a/src/main/java/ua/utility/kfsdbupgrade/MaintainableXMLConversionServiceImpl.java
+++ b/src/main/java/ua/utility/kfsdbupgrade/MaintainableXMLConversionServiceImpl.java
@@ -49,6 +49,7 @@ import org.kuali.rice.kim.api.identity.address.EntityAddress;
 import org.kuali.rice.kim.impl.identity.address.EntityAddressBo;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
+import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.InputSource;
@@ -220,12 +221,41 @@ public class MaintainableXMLConversionServiceImpl implements MaintainableXmlConv
 			throw new SAXParseException(exMsg, null, ex);
 		}
 
-		// FIXME this traversal isn't guaranteed to get the full depth
         for(Node childNode = document.getFirstChild(); childNode != null;) {
 			Node nextChild = childNode.getNextSibling();
             transformClassNode(document, childNode);
+            // Also Transform first level Children which have class attribute
+            NodeList children = childNode.getChildNodes();        
+            for (int n = 0; n < children.getLength(); n++) {
+            	Node child = children.item(n);
+            	if ((child != null) && (child.getNodeType() == Node.ELEMENT_NODE) && (child.hasAttributes())) {
+        			NamedNodeMap childAttributes = child.getAttributes();
+        			if (childAttributes.item(0).getNodeName() == "class") {
+        				String childClassName = childAttributes.item(0).getNodeValue();
+        	            if(classPropertyRuleMap.containsKey(childClassName)) {
+        	            	Map<String, String> propertyMappings = classPropertyRuleMap.get(childClassName);
+        	            	NodeList nestedChildren = child.getChildNodes();            	     
+        	                for (int i = 0; i < nestedChildren.getLength()-1; i++) {
+        	                	Node property = nestedChildren.item(i);
+        	                	String propertyName = property.getNodeName();
+        	                	if ((property.getNodeType() == Node.ELEMENT_NODE) && (propertyMappings != null) && (propertyMappings.containsKey(propertyName))) {
+    	            				String newPropertyName = propertyMappings.get(propertyName);
+    	            				if(StringUtils.isNotBlank(newPropertyName)) {
+    	            					document.renameNode(property, null, newPropertyName);
+    	            					propertyName = newPropertyName;
+    	            				} else {
+    	            					// If there is no replacement name then the element needs to be removed
+    	            					child.removeChild(property);
+    	            				}           	                		           	                		
+        	                	}
+        	                }
+        			    }
+        		    }                 
+            	}				
+			}
             childNode = nextChild;
-        }
+        }		
+
 
 		/*
 		 * the default logic that traverses over the document tree doesn't

--- a/src/main/java/ua/utility/kfsdbupgrade/MaintainableXMLConversionServiceImpl.java
+++ b/src/main/java/ua/utility/kfsdbupgrade/MaintainableXMLConversionServiceImpl.java
@@ -229,9 +229,9 @@ public class MaintainableXMLConversionServiceImpl implements MaintainableXmlConv
             for (int n = 0; n < children.getLength(); n++) {
             	Node child = children.item(n);
             	if ((child != null) && (child.getNodeType() == Node.ELEMENT_NODE) && (child.hasAttributes())) {
-        			NamedNodeMap childAttributes = child.getAttributes();
-        			if (childAttributes.item(0).getNodeName() == "class") {
-        				String childClassName = childAttributes.item(0).getNodeValue();
+					NamedNodeMap childAttributes = child.getAttributes();
+					if (childAttributes.item(0).getNodeName() == "class") {
+        	            String childClassName = childAttributes.item(0).getNodeValue();
         	            if(classPropertyRuleMap.containsKey(childClassName)) {
         	            	Map<String, String> propertyMappings = classPropertyRuleMap.get(childClassName);
         	            	NodeList nestedChildren = child.getChildNodes();            	     
@@ -249,10 +249,10 @@ public class MaintainableXMLConversionServiceImpl implements MaintainableXmlConv
     	            				}           	                		           	                		
         	                	}
         	                }
-        			    }
+        	            }
         		    }                 
             	}				
-			}
+            }
             childNode = nextChild;
         }		
 

--- a/src/main/java/ua/utility/kfsdbupgrade/MaintainableXMLConversionServiceImpl.java
+++ b/src/main/java/ua/utility/kfsdbupgrade/MaintainableXMLConversionServiceImpl.java
@@ -228,10 +228,10 @@ public class MaintainableXMLConversionServiceImpl implements MaintainableXmlConv
             NodeList children = childNode.getChildNodes();        
             for (int n = 0; n < children.getLength(); n++) {
             	Node child = children.item(n);
-            	if ((child != null) && (child.getNodeType() == Node.ELEMENT_NODE) && (child.hasAttributes())) {
-					NamedNodeMap childAttributes = child.getAttributes();
-					if (childAttributes.item(0).getNodeName() == "class") {
-        	            String childClassName = childAttributes.item(0).getNodeValue();
+                if ((child != null) && (child.getNodeType() == Node.ELEMENT_NODE) && (child.hasAttributes())) {
+                    NamedNodeMap childAttributes = child.getAttributes();
+                    if (childAttributes.item(0).getNodeName() == "class") {
+                        String childClassName = childAttributes.item(0).getNodeValue();
         	            if(classPropertyRuleMap.containsKey(childClassName)) {
         	            	Map<String, String> propertyMappings = classPropertyRuleMap.get(childClassName);
         	            	NodeList nestedChildren = child.getChildNodes();            	     
@@ -247,11 +247,11 @@ public class MaintainableXMLConversionServiceImpl implements MaintainableXmlConv
     	            					// If there is no replacement name then the element needs to be removed
     	            					child.removeChild(property);
     	            				}           	                		           	                		
-        	                	}
+        	                    }
         	                }
         	            }
-        		    }                 
-            	}				
+                    }                 
+                }				
             }
             childNode = nextChild;
         }		

--- a/src/main/resources/MaintainableXMLUpgradeRules.xml
+++ b/src/main/resources/MaintainableXMLUpgradeRules.xml
@@ -85,10 +85,6 @@
     </pattern>
  <!-- revert to kuali version for the following to objects -->
     <pattern>
-      <match>edu.arizona.kfs.module.cam.document.AssetMaintainableImpl</match>
-      <replacement>org.kuali.kfs.module.cam.document.AssetMaintainableImpl</replacement>
-    </pattern>
-    <pattern>
       <match>edu.arizona.kfs.vnd.document.VendorMaintainableImpl</match>
       <replacement>org.kuali.kfs.vnd.document.VendorMaintainableImpl</replacement>
     </pattern>
@@ -164,9 +160,14 @@
       <match>org.kuali.rice.kns.maintenance.KualiMaintainableImpl</match>
       <replacement>org.kuali.kfs.sys.document.FinancialSystemMaintainable</replacement>
     </pattern>
+    <pattern>
+      <match>edu.arizona.kfs.module.cam.businessobject.AssetAwardHistory</match>
+      <replacement>edu.arizona.kfs.module.cam.businessobject.AssetAccountResponsibility</replacement>
+    </pattern>     
   </rule>
 
-  <!-- Rules specifying any change in class properties.
+  <!--  Rules specifying any change in class properties.
+        class is the destination class
         Empty replacement tag will remove that property from the class.
         Uses XPath to match names, can use wildcards
   -->
@@ -434,6 +435,13 @@
         <replacement></replacement>
       </pattern>
     </pattern>
+    <pattern>
+      <class>edu.arizona.kfs.module.cam.businessobject.AssetExtension</class>
+      <pattern>
+        <match>assetAwardHistory</match>
+        <replacement>assetAccountResponsibilities</replacement>
+      </pattern>
+    </pattern>       
   </rule>
 
   <!-- Rules for any changes Dates from the format YYYY-MM-DD to other format.  The


### PR DESCRIPTION
UAF-5564 : KFS7 STG Receive a Conversion STE When Attempting to View Enroute/Legacy 3.0 CASM Documents. Added AssetExtension upgrade properties to rule name='maint_doc_changed_class_properties' and subsidiary classes to rule name='maint_doc_classname_changes' of 'resources\MaintainableXMLUpgradeRules.xml'. Removed no longer needed AssetMaintainable classes from rule name='maint_doc_classname_changes' of 'resources\MaintainableXMLUpgradeRules.xml'. Modified 'kfsdbupgrade\MaintainableXMLConversionServiceImpl.java' 'transformSection' method to transform the properties of nested extension class attribute nodes.