### PR TITLE
UAF-5995 BUG - MOD UAF-48 - Unable to view historic PCDM documents

### DIFF
--- a/src/main/java/ua/utility/kfsdbupgrade/MaintainableXMLConversionServiceImpl.java
+++ b/src/main/java/ua/utility/kfsdbupgrade/MaintainableXMLConversionServiceImpl.java
@@ -237,6 +237,7 @@ public class MaintainableXMLConversionServiceImpl implements MaintainableXmlConv
 		migrateAccountExtensionObjects(document);
 		migrateClassAsAttribute(document);
 		removeAutoIncrementSetElements(document);
+		removeReconcilerGroup(document);
 		catchMissedTypedArrayListElements(document);
 
         TransformerFactory transFactory = TransformerFactory.newInstance();
@@ -526,6 +527,26 @@ public class MaintainableXMLConversionServiceImpl implements MaintainableXmlConv
 				Node parent = match.getParentNode();
 				LOGGER.info("Removing element 'edu.arizona.kfs.module.cam.businessobject.AssetExtension' in "
 						+ parent.getNodeName());
+				parent.removeChild(match);
+			}
+		} catch (XPathExpressionException e) {
+			LOGGER.error("XPathException encountered: ", e);
+		}
+	}
+	/*
+	 * UAF-5995
+	 * Used to remove the reconcilerGroup and its child nodes for the ProcurementCardDefault doc
+	 */
+	private void removeReconcilerGroup(Document document) {
+		XPath xpath = XPathFactory.newInstance().newXPath();
+		XPathExpression expr = null;
+		try {
+			expr = xpath.compile("//reconcilerGroup");
+			NodeList matchingNodes = (NodeList) expr.evaluate(document, XPathConstants.NODESET);
+			for (int i = 0; i < matchingNodes.getLength(); i++) {
+				Node match = matchingNodes.item(i);
+				Node parent = match.getParentNode();
+				LOGGER.trace("Removing element 'reconcilerGroup' in " + parent.getNodeName());
 				parent.removeChild(match);
 			}
 		} catch (XPathExpressionException e) {


### PR DESCRIPTION
The following changes fixes the following exception.  

```
**--- Debugging information ----
cause-exception     : com.thoughtworks.xstream.converters.reflection.ObjectAccessException
cause-message       : Cannot create type by JDK serialization
class               : org.kuali.rice.kim.framework.group.GroupEbo
required-type       : org.kuali.rice.kim.framework.group.GroupEbo
converter-type      : com.thoughtworks.xstream.converters.reflection.ReflectionConverter
path                : /edu.arizona.kfs.fp.businessobject.ProcurementCardDefault/reconcilerGroup
line number         : 31
class[1]            : edu.arizona.kfs.fp.businessobject.ProcurementCardDefault
version             : 1.4.9**
```
*Note that the original exception mentioned in the UAF-5995 Jira  ` message  : No such field edu.arizona.kfs.fp.businessobject.ProcurementCardDefault.org.kuali.rice.kim.api.identity.address.EntityAddress` was fixed by UAF-5951

1) Add and invoke the **removeReconcilerGroup(Document document)**  method to **src/main/java/ua/utility/kfsdbupgrade/MaintainableXMLConversionServiceImpl.java**.  This will get rid of the reconcilerGroup and its child nodes. 