### PR TITLE
UAF-6104 Bug - Cannot complete a search for PAAT doc type

### DIFF
--- a/src/main/resources/MaintainableXMLUpgradeRules.xml
+++ b/src/main/resources/MaintainableXMLUpgradeRules.xml
@@ -83,6 +83,10 @@
       <match>org.kuali.rice.kns.document.ParameterMaintainable</match>
       <replacement>org.kuali.rice.coreservice.web.parameter.ParameterMaintainableImpl</replacement>
     </pattern>
+    <pattern>
+      <match>org.kuali.kfs.pdp.businessobject.PayeeACHAccount</match>
+      <replacement>edu.arizona.kfs.pdp.businessobject.PayeeACHAccount</replacement>
+    </pattern>
  <!-- revert to kuali version for the following to objects -->
     <pattern>
       <match>edu.arizona.kfs.vnd.document.VendorMaintainableImpl</match>


### PR DESCRIPTION
## Issue

**java.lang.IllegalArgumentException: invalid (blank) docTypeName** when trying to click on a Document Id in the PAAT doc search results.
## Solution
To understand why the documents won't open, I ran the **SingleXmlUpgrader** against the several PAAT maintenance docs and found that the document still contained the **org.kuali.kfs.pdp.businessobject.PayeeACHAccount** as a node.  

Since the **PayeeACHAccount** is now in an edu.arizona package as explained in **https://github.com/ua-eas/financials/pull/113** , I added a rule in **MaintainableXMLUpgradeRules.xml** to replace the **org.kuali.kfs.pdp.businessobject.PayeeACHAccount** nodes in the XML with 
**edu.arizona.kfs.pdp.businessobject.PayeeACHAccount**.  I tested this rule on several documents and wrote them to the kfs7dev db.  The documents were able to be opened. I spun up a db prototype with this
change and had the BA test the results and they were able to open the documents.

