### PR TITLE
UAF-6338 : BUG - 3.0 CSCR document STE.  Added pattern to replace class 

### DIFF
--- a/src/main/resources/MaintainableXMLUpgradeRules.xml
+++ b/src/main/resources/MaintainableXMLUpgradeRules.xml
@@ -172,6 +172,10 @@
       <match>edu.arizona.kfs.coa.businessobject.OrganizationExt</match>
       <replacement>org.kuali.kfs.krad.bo.PersistableBusinessObjectExtensionBase</replacement>
     </pattern>         
+    <pattern>
+      <match>com.rsmart.kuali.kfs.cr.businessobject.CheckReconciliation</match>
+      <replacement>edu.arizona.kfs.module.cr.businessobject.CheckReconciliation</replacement>
+    </pattern>      
   </rule>
 
   <!--  Rules specifying any change in class properties.


### PR DESCRIPTION
UAF-6338 : BUG - 3.0 CSCR document STE.  Added pattern to replace class 'com.rsmart.kuali.kfs.cr.businessobject.CheckReconciliation' with 'edu.arizona.kfs.module.cr.businessobject.CheckReconciliation' in file '\kfsdbupgrade\src\main\resources\MaintainableXMLUpgradeRules.xml'.