### PR TITLE
UAF-6485 - Adding log4j entries to suppress unimpactful errors/warnings.

### DIFF
--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -3,3 +3,12 @@ log4j.rootLogger=INFO, stdout
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.Target=System.out
 log4j.appender.stdout.layout=ua.utility.kfsdbupgrade.log.SimplePatternLayout
+
+# Suppress 100+ errors (rice ignoring modes around this class, fixed in v2.5)
+log4j.logger.org.kuali.rice.core.impl.cache.DistributedCacheManagerDecorator=FATAL
+
+# Suppress JAXB superfluous noise
+log4j.logger.org.kuali.rice.core.impl.config.property.JAXBConfigImpl=ERROR
+
+# Suppress deprecation warnings
+log4j.logger.org.kuali.rice.kew.xml.DocumentTypeXmlParser=ERROR


### PR DESCRIPTION
This clears up hundreds of error and warning messages from this job. Please see the related jira for more details.