### PR TITLE
UAF-6613 Convert IdentityManagementReviewResponsibilityMaintenanceDocument

### DIFF
--- a/src/main/resources/MaintainableXMLUpgradeRules.xml
+++ b/src/main/resources/MaintainableXMLUpgradeRules.xml
@@ -503,7 +503,14 @@
 			<match>sourceOfFundsDesc</match>
 			<replacement>sourceOfFundsDescription</replacement>
 		</pattern>
-	</pattern>          
+	</pattern>
+	<pattern> 
+      <class>org.kuali.rice.kim.impl.responsibility.ReviewResponsibilityBo</class> 
+      <pattern> 
+        <match>responsibilityId</match> 
+        <replacement>id</replacement> 
+      </pattern> 
+	</pattern>
   </rule>
 
   <!-- Rules for any changes Dates from the format YYYY-MM-DD to other format.  The


### PR DESCRIPTION
Fixed property name change from responsibilityId to id for org.kuali.rice.kim.impl.responsibility.ReviewResponsibilityBo. IdentityManagementReviewResponsibilityMaintenanceDocument is Rice document type. The fixed applied to kfs3 schema with combined kfs and rice. Then it will be separated to Rice schema by 6->7 upgrade job.