### PR TITLE
UAF-6614 Convert ITYP (Indirect Cost Recovery Type)

### DIFF
--- a/src/main/resources/MaintainableXMLUpgradeRules.xml
+++ b/src/main/resources/MaintainableXMLUpgradeRules.xml
@@ -56,7 +56,7 @@
     </pattern>
     <pattern>
       <match>org.kuali.rice.kns.bo.KualiCodeBase</match>
-      <replacement>org.kuali.rice.krad.bo.KualiCodeBase</replacement>
+      <replacement>org.kuali.kfs.krad.bo.KualiCodeBase</replacement>
     </pattern>
     <pattern>
       <match>org.kuali.rice.kim.bo.impl.PersonImpl</match>
@@ -503,7 +503,7 @@
 			<match>sourceOfFundsDesc</match>
 			<replacement>sourceOfFundsDescription</replacement>
 		</pattern>
-	</pattern>          
+	</pattern>      
   </rule>
 
   <!-- Rules for any changes Dates from the format YYYY-MM-DD to other format.  The


### PR DESCRIPTION
Along with Rice KNS separated to kfs-kns in KFS7, org.kuali.rice.krad.bo.KualiCodeBase.KualiCodeBase has been replaced in KFS7 by org.kuali.kfs.krad.bo.KualiCodeBase. Though KFS3->6, org.kuali.rice.kns.bo.KualiCodeBase was replaced by org.kuali.rice.krad.bo.KualiCodeBase.KualiCodeBase, we have to convert it to KFS7 class type, i.e.  org.kuali.kfs.krad.bo.KualiCodeBase directly in kfsdbupgrade. 