### PR TITLE
UAF-6591 Convert CountyMaintenanceDocument, StateMaintenanceDocument, PostalCodeMaintenanceDocument, CountryMaintenanceDocument

### DIFF
--- a/src/main/resources/upgrade-files/post-upgrade/sql/UAF-6591.sql
+++ b/src/main/resources/upgrade-files/post-upgrade/sql/UAF-6591.sql
@@ -5,20 +5,20 @@
 --------------------------------------------------------------------------------
 update KREW_DOC_TYP_T
     set AUTHORIZER = 'org.kuali.rice.kew.doctype.service.impl.KimDocumentTypeAuthorizer'
-    where PARNT_ID not in (select PARNT_ID from KREW_DOC_TYP_T where CUR_IND = 1 and DOC_TYP_NM ='CountyMaintenanceDocument')
+    where PARNT_ID = '329519'
     and DOC_TYP_NM = 'CountyMaintenanceDocument';
 
 update KREW_DOC_TYP_T
     set AUTHORIZER = 'org.kuali.rice.kew.doctype.service.impl.KimDocumentTypeAuthorizer'
-    where PARNT_ID not in (select PARNT_ID from KREW_DOC_TYP_T where CUR_IND = 1 and DOC_TYP_NM ='StateMaintenanceDocument')
+    where PARNT_ID = '329519'
     and DOC_TYP_NM = 'StateMaintenanceDocument';
 
 update KREW_DOC_TYP_T
     set AUTHORIZER = 'org.kuali.rice.kew.doctype.service.impl.KimDocumentTypeAuthorizer'
-    where PARNT_ID not in (select PARNT_ID from KREW_DOC_TYP_T where CUR_IND = 1 and DOC_TYP_NM ='PostalCodeMaintenanceDocument')
+    where PARNT_ID = '329519'
     and DOC_TYP_NM = 'PostalCodeMaintenanceDocument';
 
 update KREW_DOC_TYP_T
     set AUTHORIZER = 'org.kuali.rice.kew.doctype.service.impl.KimDocumentTypeAuthorizer'
-    where PARNT_ID not in (select PARNT_ID from KREW_DOC_TYP_T where CUR_IND = 1 and DOC_TYP_NM ='CountryMaintenanceDocument')
+    where PARNT_ID = '329519'
     and DOC_TYP_NM = 'CountryMaintenanceDocument';


### PR DESCRIPTION
Update the authorizer for PARNT_ID 329519.  The original logic to only update where the PARNT_ID is non-current would not work because at the point when these scripts are run, the PARNT_ID of 329519 would have been the most current and thus would not be affected by the updates. 