### PR TITLE
UAF-6591 Convert CountyMaintenanceDocument, StateMaintenanceDocument, PostalCodeMaintenanceDocument, CountryMaintenanceDocument

### DIFF
--- a/src/main/resources/upgrade-files/post-upgrade/sql/UAF-6591.sql
+++ b/src/main/resources/upgrade-files/post-upgrade/sql/UAF-6591.sql
@@ -5,20 +5,20 @@
 --------------------------------------------------------------------------------
 update KREW_DOC_TYP_T
     set AUTHORIZER = 'org.kuali.rice.kew.doctype.service.impl.KimDocumentTypeAuthorizer'
-    where PARNT_ID = '329519'
+    where DOC_TYP_ID in ('330623','320488')
     and DOC_TYP_NM = 'CountyMaintenanceDocument';
 
 update KREW_DOC_TYP_T
     set AUTHORIZER = 'org.kuali.rice.kew.doctype.service.impl.KimDocumentTypeAuthorizer'
-    where PARNT_ID = '329519'
+    where DOC_TYP_ID in ('330627','320494')
     and DOC_TYP_NM = 'StateMaintenanceDocument';
 
 update KREW_DOC_TYP_T
     set AUTHORIZER = 'org.kuali.rice.kew.doctype.service.impl.KimDocumentTypeAuthorizer'
-    where PARNT_ID = '329519'
+    where DOC_TYP_ID in ('330624','320493')
     and DOC_TYP_NM = 'PostalCodeMaintenanceDocument';
 
 update KREW_DOC_TYP_T
     set AUTHORIZER = 'org.kuali.rice.kew.doctype.service.impl.KimDocumentTypeAuthorizer'
-    where PARNT_ID = '329519'
+    where DOC_TYP_ID in ('330625','320487')
     and DOC_TYP_NM = 'CountryMaintenanceDocument';


### PR DESCRIPTION
Amanda suggested that it is probably better to use the DOC_TYP_ID rather than the PARNT_ID because 
"if by chance parent doc being re-ingestered then it will update children doc type of parent doc_typ_id. if we use doc_typ_id directly, we decoupling of running orders".