### PR TITLE
UAF-6757 Upgrade ARG - Asset Retirement Global Maintenance Documents

### DIFF
--- a/src/main/resources/MaintainableXMLUpgradeRules.xml
+++ b/src/main/resources/MaintainableXMLUpgradeRules.xml
@@ -208,6 +208,10 @@
 		<match>org.kuali.kfs.module.cab.businessobject.AssetTransactionType</match>
 		<replacement>org.kuali.kfs.module.cam.businessobject.AssetTransactionType</replacement>
 	</pattern>
+    <pattern>
+		<match>org.kuali.kfs.module.cam.businessobject.AssetRetirementGlobal</match>
+		<replacement>edu.arizona.kfs.module.cam.businessobject.AssetRetirementGlobal</replacement>
+	</pattern>
   </rule>
 
   <!--  Rules specifying any change in class properties.


### PR DESCRIPTION
Open ARG ran into NPE when loading BO DD which returns NULL. The root cause is ARG has been extended with new edu ARG BO class. ARG has reference to delivered BO and attempted to load from DD which is no longer exist. The fix is to replace org ARG BO by edu ARG BO, i.e. replace org.kuali.kfs.module.cam.businessobject.AssetRetirementGlobal by edu.arizona.kfs.module.cam.businessobject.AssetRetirementGlobal