### PR TITLE
UAF-6765 Upgrade SACC - Sub-Account - Edit SubAccount Maintenance Documents that so far have been missed and still fail to open.

### DIFF
--- a/src/main/resources/MaintainableXMLUpgradeRules.xml
+++ b/src/main/resources/MaintainableXMLUpgradeRules.xml
@@ -568,6 +568,17 @@
         <replacement>id</replacement> 
       </pattern> 
 	</pattern>
+    <pattern>
+      <class>org.kuali.kfs.coa.businessobject.A21SubAccount</class>
+      <pattern>
+        <match>indirectCostRecoveryAccountNumber</match>
+        <replacement></replacement>
+      </pattern>
+      <pattern>
+        <match>indirectCostRecoveryChartOfAccountsCode</match>
+        <replacement></replacement>
+      </pattern>
+    </pattern>
   </rule>
 
   <!-- Rules for any changes Dates from the format YYYY-MM-DD to other format.  The


### PR DESCRIPTION
Add rules to remove indirectCostRecoveryAccountNumber and indirectCostRecoveryChartOfAccountsCode from the A21SubAccount xml because those properties do not exist in kfs7. This will allow these documents to be opened in kfs7.